### PR TITLE
Update generator-linux.yml

### DIFF
--- a/.github/workflows/generator-linux.yml
+++ b/.github/workflows/generator-linux.yml
@@ -98,7 +98,7 @@ jobs:
               arch: x86_64,
               target: x86_64-unknown-linux-gnu,
               distro: ubuntu18.04,
-              on: ubuntu-20.04,
+              on: ubuntu-22.04,
               deb_arch: amd64,
               vcpkg-triplet: x64-linux,
             }


### PR DESCRIPTION
Ubuntu 20.04 runer is deprecated
https://github.com/actions/runner-images/issues/11101