### PR TITLE
views.py: Fix port in URL for setup / downloads-zip

### DIFF
--- a/rdgenerator/views.py
+++ b/rdgenerator/views.py
@@ -100,7 +100,11 @@ def generator_view(request):
             myuuid = str(uuid.uuid4())
             protocol = _settings.PROTOCOL
             host = request.get_host()
-            full_url = f"{protocol}://{host}"
+            # --- Fix: Port in URL for setup / download-zip
+            # --- protocol = _settings.PROTOCOL
+            # --- host = request.get_host()
+            # --- full_url = f"{protocol}://{host}"
+            full_url = f"{protocol}://{host}" if _settings.GENURL else f"{_settings.PROTOCOL}://{request.get_host()}"
             try:
                 iconfile = form.cleaned_data.get('iconfile')
                 if not iconfile:


### PR DESCRIPTION
If your are on the self hosted version and <our URL contains an specific port, you get an issue qithin the workflow and [setup / download-zip].
E.g. URL: https://www.my-domain.com:4433 --> [setup / download-zip] won't work, because
`input_data = json.loads('{"url": "https://www.my-domain.com/" ...`

This is issued by line 103 in rdgen / rdgenerator / views.py using
`full_url = f"{protocol}://{host}"`

I changed ist to
`full_url = f"{protocol}://{host}" if _settings.GENURL else f"{_settings.PROTOCOL}://{request.get_host()}"`
and now it works (2 time test run).