### PR TITLE
fix: read file content into memory before closing file handle in down…

### DIFF
--- a/rdgenerator/views.py
+++ b/rdgenerator/views.py
@@ -395,14 +395,13 @@ def check_for_file(request):
 def download(request):
     filename = request.GET['filename']
     uuid = request.GET['uuid']
-    #filename = filename+".exe"
-    file_path = os.path.join('exe',uuid,filename)
+    file_path = os.path.join('exe', uuid, filename)
     with open(file_path, 'rb') as file:
-        response = HttpResponse(file, headers={
-            'Content-Type': 'application/vnd.microsoft.portable-executable',
-            'Content-Disposition': f'attachment; filename="{filename}"'
-        })
-
+        content = file.read()
+    response = HttpResponse(content, headers={
+        'Content-Type': 'application/vnd.microsoft.portable-executable',
+        'Content-Disposition': f'attachment; filename="{filename}"'
+    })
     return response
 
 def get_png(request):


### PR DESCRIPTION
## Fix file download returning 502 Bad Gateway

### Problem
The `download` view opened a file and passed the file object directly 
to `HttpResponse` inside a `with` block. By the time the response was 
returned and Traefik/gunicorn tried to stream the content, the `with` 
block had already closed the file handle — causing gunicorn to hang 
and Traefik to return 502 Bad Gateway.

### Fix
Read the entire file content into memory inside the `with` block before 
constructing the `HttpResponse`, ensuring the file is fully loaded 
before the handle is closed.

### Testing
Verified that downloading large `.exe` files (24MB+) via reverse proxy 
(Traefik + gunicorn) returns 200 with correct content after this fix.