### PR TITLE
feat: add JSON API endpoints for programmatic access

### DIFF
--- a/rdgen/urls.py
+++ b/rdgen/urls.py
@@ -17,6 +17,7 @@ Including another URLconf
 import django
 
 from rdgenerator import views as views
+from rdgenerator import api_views as api_views
 if django.__version__.split('.')[0]>='4':
     from django.urls import re_path as url
 else:
@@ -34,4 +35,7 @@ urlpatterns = [
     url(r'^save_custom_client',views.save_custom_client),
     url(r'^get_zip',views.get_zip),
     url(r'^cleanzip',views.cleanup_secrets),
+    # JSON API endpoints
+    url(r'^api/generate$',api_views.api_generate),
+    url(r'^api/status$',api_views.api_status),
 ]

--- a/rdgenerator/api_views.py
+++ b/rdgenerator/api_views.py
@@ -1,0 +1,165 @@
+import json
+from django.http import JsonResponse
+from django.conf import settings as _settings
+from .views import generate_custom_client, _get_run_status
+
+
+# Field validation constraints (mirrored from GenerateForm)
+PLATFORM_CHOICES = ['windows', 'windows-x86', 'linux', 'android', 'macos']
+VERSION_CHOICES = ['master', '1.4.9', '1.4.8', '1.4.7', '1.4.6', '1.4.5', '1.4.4', '1.4.3', '1.4.2', '1.4.1', '1.4.0']
+DIRECTION_CHOICES = ['incoming', 'outgoing', 'both']
+INSTALLATION_CHOICES = ['installationY', 'installationN']
+SETTINGS_CHOICES = ['settingsY', 'settingsN']
+THEME_CHOICES = ['light', 'dark', 'system']
+THEME_DORO_CHOICES = ['default', 'override']
+PASS_APPROVE_MODE_CHOICES = ['password', 'click', 'password-click']
+PERMISSIONS_DORO_CHOICES = ['default', 'override']
+PERMISSIONS_TYPE_CHOICES = ['custom', 'full', 'view']
+
+# Boolean fields
+BOOL_FIELDS = [
+    'delayFix', 'xOffline', 'hidecm', 'removeNewVersionNotif',
+    'denyLan', 'enableDirectIP', 'autoClose',
+    'enableKeyboard', 'enableClipboard', 'enableFileTransfer', 'enableAudio',
+    'enableTCP', 'enableRemoteRestart', 'enableRecording', 'enableBlockingInput',
+    'enableRemoteModi', 'removeWallpaper', 'enablePrinter', 'enableCamera', 'enableTerminal',
+]
+
+# Optional string fields (no validation needed, just accept as-is)
+OPTIONAL_STR_FIELDS = [
+    'sh_secret_field', 'serverIP', 'key', 'apiServer', 'urlLink', 'downloadLink',
+    'appname', 'compname', 'androidappid', 'permanentPassword',
+    'defaultManual', 'overrideManual',
+    'iconbase64', 'logobase64', 'privacybase64',
+]
+
+
+def validate_generate_params(data):
+    """
+    Validate JSON API parameters against the same constraints as GenerateForm.
+
+    Returns:
+        tuple: (cleaned_data dict, errors dict)
+        If errors is non-empty, validation failed.
+    """
+    errors = {}
+    cleaned = {}
+
+    # Required string field
+    exename = data.get('exename', '')
+    if not exename:
+        errors['exename'] = 'This field is required.'
+    else:
+        cleaned['exename'] = exename
+
+    # Choice fields
+    choice_validations = {
+        'platform': (PLATFORM_CHOICES, 'windows'),
+        'version': (VERSION_CHOICES, '1.4.9'),
+        'direction': (DIRECTION_CHOICES, 'both'),
+        'installation': (INSTALLATION_CHOICES, 'installationY'),
+        'settings': (SETTINGS_CHOICES, 'settingsY'),
+        'theme': (THEME_CHOICES, 'system'),
+        'themeDorO': (THEME_DORO_CHOICES, 'default'),
+        'passApproveMode': (PASS_APPROVE_MODE_CHOICES, 'password-click'),
+        'permissionsDorO': (PERMISSIONS_DORO_CHOICES, 'default'),
+        'permissionsType': (PERMISSIONS_TYPE_CHOICES, 'custom'),
+    }
+    for field, (choices, default) in choice_validations.items():
+        value = data.get(field, default)
+        if value not in choices:
+            errors[field] = f'Invalid choice. Must be one of: {choices}'
+        else:
+            cleaned[field] = value
+
+    # Boolean fields
+    for field in BOOL_FIELDS:
+        value = data.get(field, False)
+        if not isinstance(value, bool):
+            errors[field] = 'Must be a boolean value.'
+        else:
+            cleaned[field] = value
+
+    # Optional string fields
+    for field in OPTIONAL_STR_FIELDS:
+        cleaned[field] = data.get(field, '')
+
+    # File fields are not used in API mode (base64 fields are used instead)
+    cleaned['iconfile'] = None
+    cleaned['logofile'] = None
+    cleaned['privacyfile'] = None
+
+    return cleaned, errors
+
+
+def api_generate(request):
+    """
+    POST /api/generate
+
+    Accepts a JSON body with client configuration parameters and triggers
+    the custom client generation process via GitHub Actions.
+
+    Returns JSON with success status, uuid, filename, platform, and log_url.
+    """
+    if request.method != 'POST':
+        return JsonResponse({"success": False, "error": "Method not allowed. Use POST."}, status=405)
+
+    try:
+        data = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError) as e:
+        return JsonResponse({"success": False, "error": f"Invalid JSON: {str(e)}"}, status=400)
+
+    cleaned, errors = validate_generate_params(data)
+    if errors:
+        return JsonResponse({
+            "success": False,
+            "error": "Validation errors",
+            "details": errors
+        }, status=400)
+
+    # Build full_url the same way as generator_view
+    full_url = f"{_settings.PROTOCOL}://{request.get_host()}" if _settings.GENURL else f"{_settings.PROTOCOL}://{request.get_host()}"
+
+    result = generate_custom_client(cleaned, full_url)
+
+    if result['success']:
+        # Add convenience URLs for the API consumer
+        result['status_url'] = f"/api/status?uuid={result['uuid']}&platform={result['platform']}&filename={result['filename']}"
+        return JsonResponse(result)
+    else:
+        return JsonResponse({"success": False, "error": result['error']}, status=result.get('status_code', 500))
+
+
+def api_status(request):
+    """
+    GET /api/status
+
+    Checks the generation status for a given UUID.
+    Returns JSON with status, uuid, and optional log_url/filename/platform.
+    """
+    if request.method != 'GET':
+        return JsonResponse({"success": False, "error": "Method not allowed. Use GET."}, status=405)
+
+    uuid_val = request.GET.get('uuid')
+    if not uuid_val:
+        return JsonResponse({"error": "Missing required parameter: uuid"}, status=400)
+
+    filename = request.GET.get('filename', '')
+    platform = request.GET.get('platform', '')
+
+    result = _get_run_status(uuid_val)
+
+    if not result['found']:
+        return JsonResponse({"error": "Run not found"}, status=404)
+
+    response_data = {
+        "status": result['status'],
+        "uuid": uuid_val,
+        "log_url": result['github_log_url'],
+    }
+    if filename:
+        response_data['filename'] = filename
+    if platform:
+        response_data['platform'] = platform
+
+    return JsonResponse(response_data)

--- a/rdgenerator/views.py
+++ b/rdgenerator/views.py
@@ -1,7 +1,7 @@
 import io
 from pathlib import Path
 from django.http import HttpResponse, JsonResponse, HttpResponseForbidden
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
 from django.core.files.base import ContentFile
 import os
 import secrets
@@ -18,336 +18,337 @@ from .models import GithubRun
 from PIL import Image
 from urllib.parse import quote
 
-def generator_view(request):
-    if request.method == 'POST':
-        form = GenerateForm(request.POST, request.FILES)
-        if form.is_valid():
-            user_secret = form.cleaned_data['sh_secret_field']
-            if _settings.SH_SECRET == user_secret:
-                selfhosted = True
-            else:
-                selfhosted = False
-            platform = form.cleaned_data['platform']
-            version = form.cleaned_data['version']
-            delayFix = form.cleaned_data['delayFix']
-            xOffline = form.cleaned_data['xOffline']
-            hidecm = form.cleaned_data['hidecm']
-            removeNewVersionNotif = form.cleaned_data['removeNewVersionNotif']
-            server = form.cleaned_data['serverIP']
-            key = form.cleaned_data['key']
-            apiServer = form.cleaned_data['apiServer']
-            urlLink = form.cleaned_data['urlLink']
-            downloadLink = form.cleaned_data['downloadLink']
-            if not server:
-                server = 'rs-ny.rustdesk.com' #default rustdesk server
-            if not key:
-                key = 'OeVuKk5nlHiXp+APNn0Y3pC1Iwpwn44JGqrQCsWqmBw=' #default rustdesk key
-            if not apiServer:
-                apiServer = server+":21114"
-            if not urlLink:
-                urlLink = "https://rustdesk.com"
-            if not downloadLink:
-                downloadLink = "https://rustdesk.com/download"
-            direction = form.cleaned_data['direction']
-            installation = form.cleaned_data['installation']
-            settings = form.cleaned_data['settings']
-            appname = form.cleaned_data['appname']
-            if not appname:
-                appname = "rustdesk"
-            filename = form.cleaned_data['exename']
-            compname = form.cleaned_data['compname']
-            if not compname:
-                compname = "Purslane Ltd"
-            androidappid = form.cleaned_data['androidappid']
-            if not androidappid:
-                androidappid = "com.carriez.flutter_hbb"
-            compname = compname.replace("&","\\&")
-            permPass = form.cleaned_data['permanentPassword']
-            theme = form.cleaned_data['theme']
-            themeDorO = form.cleaned_data['themeDorO']
-            #runasadmin = form.cleaned_data['runasadmin']
-            passApproveMode = form.cleaned_data['passApproveMode']
-            denyLan = form.cleaned_data['denyLan']
-            enableDirectIP = form.cleaned_data['enableDirectIP']
-            #ipWhitelist = form.cleaned_data['ipWhitelist']
-            autoClose = form.cleaned_data['autoClose']
-            permissionsDorO = form.cleaned_data['permissionsDorO']
-            permissionsType = form.cleaned_data['permissionsType']
-            enableKeyboard = form.cleaned_data['enableKeyboard']
-            enableClipboard = form.cleaned_data['enableClipboard']
-            enableFileTransfer = form.cleaned_data['enableFileTransfer']
-            enableAudio = form.cleaned_data['enableAudio']
-            enableTCP = form.cleaned_data['enableTCP']
-            enableRemoteRestart = form.cleaned_data['enableRemoteRestart']
-            enableRecording = form.cleaned_data['enableRecording']
-            enableBlockingInput = form.cleaned_data['enableBlockingInput']
-            enableRemoteModi = form.cleaned_data['enableRemoteModi']
-            removeWallpaper = form.cleaned_data['removeWallpaper']
-            defaultManual = form.cleaned_data['defaultManual']
-            overrideManual = form.cleaned_data['overrideManual']
-            enablePrinter = form.cleaned_data['enablePrinter']
-            enableCamera = form.cleaned_data['enableCamera']
-            enableTerminal = form.cleaned_data['enableTerminal']
 
-            if all(char.isascii() for char in filename):
-                filename = re.sub(r'[^\w\s-]', '_', filename).strip()
-                filename = filename.replace(" ","_")
-            else:
-                filename = "rustdesk"
-            if not all(char.isascii() for char in appname):
-                appname = "rustdesk"
-            myuuid = str(uuid.uuid4())
-            protocol = _settings.PROTOCOL
-            host = request.get_host()
-            # --- Fix: Port in URL for setup / download-zip
-            # --- protocol = _settings.PROTOCOL
-            # --- host = request.get_host()
-            # --- full_url = f"{protocol}://{host}"
-            full_url = f"{protocol}://{host}" if _settings.GENURL else f"{_settings.PROTOCOL}://{request.get_host()}"
-            try:
-                iconfile = form.cleaned_data.get('iconfile')
-                if not iconfile:
-                    iconfile = form.cleaned_data.get('iconbase64')
-                iconlink_url, iconlink_uuid, iconlink_file = save_png(iconfile,myuuid,full_url,"icon.png")
-            except:
-                print("failed to get icon, using default")
-                iconlink_url = "false"
-                iconlink_uuid = "false"
-                iconlink_file = "false"
-            try:
-                logofile = form.cleaned_data.get('logofile')
-                if not logofile:
-                    logofile = form.cleaned_data.get('logobase64')
-                logolink_url, logolink_uuid, logolink_file = save_png(logofile,myuuid,full_url,"logo.png")
-            except:
-                print("failed to get logo")
-                logolink_url = "false"
-                logolink_uuid = "false"
-                logolink_file = "false"
-            try:
-                privacyfile = form.cleaned_data.get('privacyfile')
-                if not privacyfile:
-                    privacyfile = form.cleaned_data.get('privacybase64')
-                privacylink_url, privacylink_uuid, privacylink_file = save_png(privacyfile,myuuid,full_url,"privacy.png")
-            except:
-                print("failed to get logo")
-                privacylink_url = "false"
-                privacylink_uuid = "false"
-                privacylink_file = "false"
+def generate_custom_client(params, full_url):
+    """
+    Core generation logic shared by web form and JSON API.
 
-            ###create the custom.txt json here and send in as inputs below
-            decodedCustom = {}
-            if direction != "Both":
-                decodedCustom['conn-type'] = direction
-            if installation == "installationN":
-                decodedCustom['disable-installation'] = 'Y'
-            if settings == "settingsN":
-                decodedCustom['disable-settings'] = 'Y'
-            if appname.upper != "rustdesk".upper and appname != "":
-                decodedCustom['app-name'] = appname
-            decodedCustom['override-settings'] = {}
-            decodedCustom['default-settings'] = {}
-            if permPass != "":
-                decodedCustom['password'] = permPass
-            if theme != "system":
-                if themeDorO == "default":
-                    if platform == "windows-x86":
-                        decodedCustom['default-settings']['allow-darktheme'] = 'Y' if theme == "dark" else 'N'
-                    else:
-                        decodedCustom['default-settings']['theme'] = theme
-                elif themeDorO == "override":
-                    if platform == "windows-x86":
-                        decodedCustom['override-settings']['allow-darktheme'] = 'Y' if theme == "dark" else 'N'
-                    else:
-                        decodedCustom['override-settings']['theme'] = theme
-            decodedCustom['enable-lan-discovery'] = 'N' if denyLan else 'Y'
-            #decodedCustom['direct-server'] = 'Y' if enableDirectIP else 'N'
-            decodedCustom['allow-auto-disconnect'] = 'Y' if autoClose else 'N'
-            if permissionsDorO == "default":
-                decodedCustom['default-settings']['access-mode'] = permissionsType
-                decodedCustom['default-settings']['enable-keyboard'] = 'Y' if enableKeyboard else 'N'
-                decodedCustom['default-settings']['enable-clipboard'] = 'Y' if enableClipboard else 'N'
-                decodedCustom['default-settings']['enable-file-transfer'] = 'Y' if enableFileTransfer else 'N'
-                decodedCustom['default-settings']['enable-audio'] = 'Y' if enableAudio else 'N'
-                decodedCustom['default-settings']['enable-tunnel'] = 'Y' if enableTCP else 'N'
-                decodedCustom['default-settings']['enable-remote-restart'] = 'Y' if enableRemoteRestart else 'N'
-                decodedCustom['default-settings']['enable-record-session'] = 'Y' if enableRecording else 'N'
-                decodedCustom['default-settings']['enable-block-input'] = 'Y' if enableBlockingInput else 'N'
-                decodedCustom['default-settings']['allow-remote-config-modification'] = 'Y' if enableRemoteModi else 'N'
-                decodedCustom['default-settings']['direct-server'] = 'Y' if enableDirectIP else 'N'
-                decodedCustom['default-settings']['verification-method'] = 'use-permanent-password' if hidecm else 'use-both-passwords'
-                decodedCustom['default-settings']['approve-mode'] = passApproveMode
-                decodedCustom['default-settings']['allow-hide-cm'] = 'Y' if hidecm else 'N'
-                decodedCustom['default-settings']['allow-remove-wallpaper'] = 'Y' if removeWallpaper else 'N'
-                decodedCustom['default-settings']['enable-remote-printer'] = 'Y' if enablePrinter else 'N'
-                decodedCustom['default-settings']['enable-camera'] = 'Y' if enableCamera else 'N'
-                decodedCustom['default-settings']['enable-terminal'] = 'Y' if enableTerminal else 'N'
-            else:
-                decodedCustom['override-settings']['access-mode'] = permissionsType
-                decodedCustom['override-settings']['enable-keyboard'] = 'Y' if enableKeyboard else 'N'
-                decodedCustom['override-settings']['enable-clipboard'] = 'Y' if enableClipboard else 'N'
-                decodedCustom['override-settings']['enable-file-transfer'] = 'Y' if enableFileTransfer else 'N'
-                decodedCustom['override-settings']['enable-audio'] = 'Y' if enableAudio else 'N'
-                decodedCustom['override-settings']['enable-tunnel'] = 'Y' if enableTCP else 'N'
-                decodedCustom['override-settings']['enable-remote-restart'] = 'Y' if enableRemoteRestart else 'N'
-                decodedCustom['override-settings']['enable-record-session'] = 'Y' if enableRecording else 'N'
-                decodedCustom['override-settings']['enable-block-input'] = 'Y' if enableBlockingInput else 'N'
-                decodedCustom['override-settings']['allow-remote-config-modification'] = 'Y' if enableRemoteModi else 'N'
-                decodedCustom['override-settings']['direct-server'] = 'Y' if enableDirectIP else 'N'
-                decodedCustom['override-settings']['verification-method'] = 'use-permanent-password' if hidecm else 'use-both-passwords'
-                decodedCustom['override-settings']['approve-mode'] = passApproveMode
-                decodedCustom['override-settings']['allow-hide-cm'] = 'Y' if hidecm else 'N'
-                decodedCustom['override-settings']['allow-remove-wallpaper'] = 'Y' if removeWallpaper else 'N'
-                decodedCustom['override-settings']['enable-remote-printer'] = 'Y' if enablePrinter else 'N'
-                decodedCustom['override-settings']['enable-camera'] = 'Y' if enableCamera else 'N'
-                decodedCustom['override-settings']['enable-terminal'] = 'Y' if enableTerminal else 'N'
+    Args:
+        params: dict containing all configuration fields (keys match GenerateForm field names)
+        full_url: the full URL of this service (protocol + host)
 
-            for line in defaultManual.splitlines():
-                k, value = line.split('=')
+    Returns:
+        dict with 'success' key. On success: also includes 'uuid', 'filename', 'platform', 'log_url'.
+        On failure: includes 'error' and optionally 'status_code'.
+    """
+    user_secret = params.get('sh_secret_field', '')
+    selfhosted = (_settings.SH_SECRET == user_secret)
+    platform = params.get('platform', 'windows')
+    version = params.get('version', '1.4.9')
+    delayFix = params.get('delayFix', True)
+    xOffline = params.get('xOffline', False)
+    hidecm = params.get('hidecm', False)
+    removeNewVersionNotif = params.get('removeNewVersionNotif', False)
+    server = params.get('serverIP', '')
+    key = params.get('key', '')
+    apiServer = params.get('apiServer', '')
+    urlLink = params.get('urlLink', '')
+    downloadLink = params.get('downloadLink', '')
+    if not server:
+        server = 'rs-ny.rustdesk.com' #default rustdesk server
+    if not key:
+        key = 'OeVuKk5nlHiXp+APNn0Y3pC1Iwpwn44JGqrQCsWqmBw=' #default rustdesk key
+    if not apiServer:
+        apiServer = server+":21114"
+    if not urlLink:
+        urlLink = "https://rustdesk.com"
+    if not downloadLink:
+        downloadLink = "https://rustdesk.com/download"
+    direction = params.get('direction', 'both')
+    installation = params.get('installation', 'installationY')
+    settings = params.get('settings', 'settingsY')
+    appname = params.get('appname', '')
+    if not appname:
+        appname = "rustdesk"
+    filename = params.get('exename', 'rustdesk')
+    compname = params.get('compname', '')
+    if not compname:
+        compname = "Purslane Ltd"
+    androidappid = params.get('androidappid', '')
+    if not androidappid:
+        androidappid = "com.carriez.flutter_hbb"
+    compname = compname.replace("&","\\&")
+    permPass = params.get('permanentPassword', '')
+    theme = params.get('theme', 'system')
+    themeDorO = params.get('themeDorO', 'default')
+    passApproveMode = params.get('passApproveMode', 'password-click')
+    denyLan = params.get('denyLan', False)
+    enableDirectIP = params.get('enableDirectIP', False)
+    autoClose = params.get('autoClose', False)
+    permissionsDorO = params.get('permissionsDorO', 'default')
+    permissionsType = params.get('permissionsType', 'custom')
+    enableKeyboard = params.get('enableKeyboard', True)
+    enableClipboard = params.get('enableClipboard', True)
+    enableFileTransfer = params.get('enableFileTransfer', True)
+    enableAudio = params.get('enableAudio', True)
+    enableTCP = params.get('enableTCP', True)
+    enableRemoteRestart = params.get('enableRemoteRestart', True)
+    enableRecording = params.get('enableRecording', True)
+    enableBlockingInput = params.get('enableBlockingInput', True)
+    enableRemoteModi = params.get('enableRemoteModi', False)
+    removeWallpaper = params.get('removeWallpaper', True)
+    defaultManual = params.get('defaultManual', '')
+    overrideManual = params.get('overrideManual', '')
+    enablePrinter = params.get('enablePrinter', True)
+    enableCamera = params.get('enableCamera', True)
+    enableTerminal = params.get('enableTerminal', True)
+
+    if all(char.isascii() for char in filename):
+        filename = re.sub(r'[^\w\s-]', '_', filename).strip()
+        filename = filename.replace(" ","_")
+    else:
+        filename = "rustdesk"
+    if not all(char.isascii() for char in appname):
+        appname = "rustdesk"
+    myuuid = str(uuid.uuid4())
+
+    try:
+        iconfile = params.get('iconfile')
+        if not iconfile:
+            iconfile = params.get('iconbase64')
+        iconlink_url, iconlink_uuid, iconlink_file = save_png(iconfile,myuuid,full_url,"icon.png")
+    except:
+        print("failed to get icon, using default")
+        iconlink_url = "false"
+        iconlink_uuid = "false"
+        iconlink_file = "false"
+    try:
+        logofile = params.get('logofile')
+        if not logofile:
+            logofile = params.get('logobase64')
+        logolink_url, logolink_uuid, logolink_file = save_png(logofile,myuuid,full_url,"logo.png")
+    except:
+        print("failed to get logo")
+        logolink_url = "false"
+        logolink_uuid = "false"
+        logolink_file = "false"
+    try:
+        privacyfile = params.get('privacyfile')
+        if not privacyfile:
+            privacyfile = params.get('privacybase64')
+        privacylink_url, privacylink_uuid, privacylink_file = save_png(privacyfile,myuuid,full_url,"privacy.png")
+    except:
+        print("failed to get logo")
+        privacylink_url = "false"
+        privacylink_uuid = "false"
+        privacylink_file = "false"
+
+    ###create the custom.txt json here and send in as inputs below
+    decodedCustom = {}
+    if direction != "Both":
+        decodedCustom['conn-type'] = direction
+    if installation == "installationN":
+        decodedCustom['disable-installation'] = 'Y'
+    if settings == "settingsN":
+        decodedCustom['disable-settings'] = 'Y'
+    if appname.upper != "rustdesk".upper and appname != "":
+        decodedCustom['app-name'] = appname
+    decodedCustom['override-settings'] = {}
+    decodedCustom['default-settings'] = {}
+    if permPass != "":
+        decodedCustom['password'] = permPass
+    if theme != "system":
+        if themeDorO == "default":
+            if platform == "windows-x86":
+                decodedCustom['default-settings']['allow-darktheme'] = 'Y' if theme == "dark" else 'N'
+            else:
+                decodedCustom['default-settings']['theme'] = theme
+        elif themeDorO == "override":
+            if platform == "windows-x86":
+                decodedCustom['override-settings']['allow-darktheme'] = 'Y' if theme == "dark" else 'N'
+            else:
+                decodedCustom['override-settings']['theme'] = theme
+    decodedCustom['enable-lan-discovery'] = 'N' if denyLan else 'Y'
+    #decodedCustom['direct-server'] = 'Y' if enableDirectIP else 'N'
+    decodedCustom['allow-auto-disconnect'] = 'Y' if autoClose else 'N'
+    if permissionsDorO == "default":
+        decodedCustom['default-settings']['access-mode'] = permissionsType
+        decodedCustom['default-settings']['enable-keyboard'] = 'Y' if enableKeyboard else 'N'
+        decodedCustom['default-settings']['enable-clipboard'] = 'Y' if enableClipboard else 'N'
+        decodedCustom['default-settings']['enable-file-transfer'] = 'Y' if enableFileTransfer else 'N'
+        decodedCustom['default-settings']['enable-audio'] = 'Y' if enableAudio else 'N'
+        decodedCustom['default-settings']['enable-tunnel'] = 'Y' if enableTCP else 'N'
+        decodedCustom['default-settings']['enable-remote-restart'] = 'Y' if enableRemoteRestart else 'N'
+        decodedCustom['default-settings']['enable-record-session'] = 'Y' if enableRecording else 'N'
+        decodedCustom['default-settings']['enable-block-input'] = 'Y' if enableBlockingInput else 'N'
+        decodedCustom['default-settings']['allow-remote-config-modification'] = 'Y' if enableRemoteModi else 'N'
+        decodedCustom['default-settings']['direct-server'] = 'Y' if enableDirectIP else 'N'
+        decodedCustom['default-settings']['verification-method'] = 'use-permanent-password' if hidecm else 'use-both-passwords'
+        decodedCustom['default-settings']['approve-mode'] = passApproveMode
+        decodedCustom['default-settings']['allow-hide-cm'] = 'Y' if hidecm else 'N'
+        decodedCustom['default-settings']['allow-remove-wallpaper'] = 'Y' if removeWallpaper else 'N'
+        decodedCustom['default-settings']['enable-remote-printer'] = 'Y' if enablePrinter else 'N'
+        decodedCustom['default-settings']['enable-camera'] = 'Y' if enableCamera else 'N'
+        decodedCustom['default-settings']['enable-terminal'] = 'Y' if enableTerminal else 'N'
+    else:
+        decodedCustom['override-settings']['access-mode'] = permissionsType
+        decodedCustom['override-settings']['enable-keyboard'] = 'Y' if enableKeyboard else 'N'
+        decodedCustom['override-settings']['enable-clipboard'] = 'Y' if enableClipboard else 'N'
+        decodedCustom['override-settings']['enable-file-transfer'] = 'Y' if enableFileTransfer else 'N'
+        decodedCustom['override-settings']['enable-audio'] = 'Y' if enableAudio else 'N'
+        decodedCustom['override-settings']['enable-tunnel'] = 'Y' if enableTCP else 'N'
+        decodedCustom['override-settings']['enable-remote-restart'] = 'Y' if enableRemoteRestart else 'N'
+        decodedCustom['override-settings']['enable-record-session'] = 'Y' if enableRecording else 'N'
+        decodedCustom['override-settings']['enable-block-input'] = 'Y' if enableBlockingInput else 'N'
+        decodedCustom['override-settings']['allow-remote-config-modification'] = 'Y' if enableRemoteModi else 'N'
+        decodedCustom['override-settings']['direct-server'] = 'Y' if enableDirectIP else 'N'
+        decodedCustom['override-settings']['verification-method'] = 'use-permanent-password' if hidecm else 'use-both-passwords'
+        decodedCustom['override-settings']['approve-mode'] = passApproveMode
+        decodedCustom['override-settings']['allow-hide-cm'] = 'Y' if hidecm else 'N'
+        decodedCustom['override-settings']['allow-remove-wallpaper'] = 'Y' if removeWallpaper else 'N'
+        decodedCustom['override-settings']['enable-remote-printer'] = 'Y' if enablePrinter else 'N'
+        decodedCustom['override-settings']['enable-camera'] = 'Y' if enableCamera else 'N'
+        decodedCustom['override-settings']['enable-terminal'] = 'Y' if enableTerminal else 'N'
+
+    if defaultManual:
+        for line in defaultManual.splitlines():
+            if '=' in line:
+                k, value = line.split('=', 1)
                 decodedCustom['default-settings'][k.strip()] = value.strip()
 
-            for line in overrideManual.splitlines():
-                k, value = line.split('=')
+    if overrideManual:
+        for line in overrideManual.splitlines():
+            if '=' in line:
+                k, value = line.split('=', 1)
                 decodedCustom['override-settings'][k.strip()] = value.strip()
-            
-            decodedCustomJson = json.dumps(decodedCustom)
+    
+    decodedCustomJson = json.dumps(decodedCustom)
 
-            string_bytes = decodedCustomJson.encode("ascii")
-            base64_bytes = base64.b64encode(string_bytes)
-            encodedCustom = base64_bytes.decode("ascii")
+    string_bytes = decodedCustomJson.encode("ascii")
+    base64_bytes = base64.b64encode(string_bytes)
+    encodedCustom = base64_bytes.decode("ascii")
 
-            # #github limits inputs to 10, so lump extras into one with json
-            # extras = {}
-            # extras['genurl'] = _settings.GENURL
-            # #extras['runasadmin'] = runasadmin
-            # extras['urlLink'] = urlLink
-            # extras['downloadLink'] = downloadLink
-            # extras['delayFix'] = 'true' if delayFix else 'false'
-            # extras['rdgen'] = 'true'
-            # extras['xOffline'] = 'true' if xOffline else 'false'
-            # extras['removeNewVersionNotif'] = 'true' if removeNewVersionNotif else 'false'
-            # extras['compname'] = compname
-            # extras['androidappid'] = androidappid
-            # extra_input = json.dumps(extras)
-
-            ####from here run the github action, we need user, repo, access token.
-            if platform == 'windows':
-                url = 'https://api.github.com/repos/'+_settings.GHUSER+'/'+_settings.REPONAME+'/actions/workflows/generator-windows.yml/dispatches'
-                if selfhosted:
-                    url = 'https://api.github.com/repos/'+_settings.GHUSER+'/'+_settings.REPONAME+'/actions/workflows/sh-generator-windows.yml/dispatches'
-            if platform == 'windows-x86':
-                url = 'https://api.github.com/repos/'+_settings.GHUSER+'/'+_settings.REPONAME+'/actions/workflows/generator-windows-x86.yml/dispatches'
-            elif platform == 'linux':
-                url = 'https://api.github.com/repos/'+_settings.GHUSER+'/'+_settings.REPONAME+'/actions/workflows/generator-linux.yml/dispatches'
-            elif platform == 'android':
-                url = 'https://api.github.com/repos/'+_settings.GHUSER+'/'+_settings.REPONAME+'/actions/workflows/generator-android.yml/dispatches'
-            elif platform == 'macos':
-                url = 'https://api.github.com/repos/'+_settings.GHUSER+'/'+_settings.REPONAME+'/actions/workflows/generator-macos.yml/dispatches'
-            else:
-                url = 'https://api.github.com/repos/'+_settings.GHUSER+'/'+_settings.REPONAME+'/actions/workflows/generator-windows.yml/dispatches'
-                if selfhosted:
-                    url = 'https://api.github.com/repos/'+_settings.GHUSER+'/'+_settings.REPONAME+'/actions/workflows/sh-generator-windows.yml/dispatches'
-
-            #url = 'https://api.github.com/repos/'+_settings.GHUSER+'/rustdesk/actions/workflows/test.yml/dispatches'  
-            inputs_raw = {
-                "server":server,
-                "key":key,
-                "apiServer":apiServer,
-                "custom":encodedCustom,
-                "uuid":myuuid,
-                "iconlink_url":iconlink_url,
-                "iconlink_uuid":iconlink_uuid,
-                "iconlink_file":iconlink_file,
-                "logolink_url":logolink_url,
-                "logolink_uuid":logolink_uuid,
-                "logolink_file":logolink_file,
-                "privacylink_url":privacylink_url,
-                "privacylink_uuid":privacylink_uuid,
-                "privacylink_file":privacylink_file,
-                "appname":appname,
-                "genurl":_settings.GENURL,
-                "urlLink":urlLink,
-                "downloadLink":downloadLink,
-                "delayFix": 'true' if delayFix else 'false',
-                "rdgen":'true',
-                "xOffline": 'true' if xOffline else 'false',
-                "removeNewVersionNotif": 'true' if removeNewVersionNotif else 'false',
-                "compname": compname,
-                "androidappid":androidappid,
-                "filename":filename
-            }
-
-            temp_json_path = f"data_{uuid.uuid4()}.json"
-            zip_filename = f"secrets_{uuid.uuid4()}.zip"
-            zip_path = "temp_zips/%s" % (zip_filename)
-            Path("temp_zips").mkdir(parents=True, exist_ok=True)
-
-            with open(temp_json_path, "w") as f:
-                json.dump(inputs_raw, f)
-
-            with pyzipper.AESZipFile(zip_path, 'w', compression=pyzipper.ZIP_LZMA, encryption=pyzipper.WZ_AES) as zf:
-                zf.setpassword(_settings.ZIP_PASSWORD.encode())
-                zf.write(temp_json_path, arcname="secrets.json")
-
-            if os.path.exists(temp_json_path):
-                os.remove(temp_json_path)
-
-            zipJson = {}
-            zipJson['url'] = full_url
-            zipJson['file'] = zip_filename
-
-            zip_url = json.dumps(zipJson)
-
-            data = {
-                "ref":_settings.GHBRANCH,
-                "inputs":{
-                    "version":version,
-                    "zip_url":zip_url
-                },
-                "return_run_details": True
-            } 
-            #print(data)
-            headers = {
-                'Accept':  'application/vnd.github+json',
-                'Content-Type': 'application/json',
-                'Authorization': 'Bearer '+_settings.GHBEARER,
-                'X-GitHub-Api-Version': '2026-03-10'
-            }
-            new_github_run = GithubRun(
-                uuid=myuuid,
-                status="Starting generator...please wait"
-            )
-            try:
-                response = requests.post(url, json=data, headers=headers)
-                #print(response)
-                if response.status_code == 204 or response.status_code == 200:
-                    github_data = response.json()
-                    print(github_data)
-                    new_github_run.github_run_id = github_data.get('workflow_run_id')
-                    new_github_run.status = "in_progress"
-                    new_github_run.save()
-
-                    return render(request, 'waiting.html', {'filename':filename, 'uuid':myuuid, 'status':"Starting generator...please wait", 'platform':platform, 'log_url': github_data.get('html_url')})
-                else:
-                    #new_github_run.delete()
-                    return JsonResponse({"error": "GitHub rejected the start request"}, status=500)
-            except Exception as e:
-                #new_github_run.delete()
-                return JsonResponse({"error": f"Connection error: {str(e)}"}, status=500)
+    ####from here run the github action, we need user, repo, access token.
+    if platform == 'windows':
+        url = 'https://api.github.com/repos/'+_settings.GHUSER+'/'+_settings.REPONAME+'/actions/workflows/generator-windows.yml/dispatches'
+        if selfhosted:
+            url = 'https://api.github.com/repos/'+_settings.GHUSER+'/'+_settings.REPONAME+'/actions/workflows/sh-generator-windows.yml/dispatches'
+    if platform == 'windows-x86':
+        url = 'https://api.github.com/repos/'+_settings.GHUSER+'/'+_settings.REPONAME+'/actions/workflows/generator-windows-x86.yml/dispatches'
+    elif platform == 'linux':
+        url = 'https://api.github.com/repos/'+_settings.GHUSER+'/'+_settings.REPONAME+'/actions/workflows/generator-linux.yml/dispatches'
+    elif platform == 'android':
+        url = 'https://api.github.com/repos/'+_settings.GHUSER+'/'+_settings.REPONAME+'/actions/workflows/generator-android.yml/dispatches'
+    elif platform == 'macos':
+        url = 'https://api.github.com/repos/'+_settings.GHUSER+'/'+_settings.REPONAME+'/actions/workflows/generator-macos.yml/dispatches'
     else:
-        form = GenerateForm()
-    #return render(request, 'maintenance.html')
-    return render(request, 'generator.html', {'form': form})
+        url = 'https://api.github.com/repos/'+_settings.GHUSER+'/'+_settings.REPONAME+'/actions/workflows/generator-windows.yml/dispatches'
+        if selfhosted:
+            url = 'https://api.github.com/repos/'+_settings.GHUSER+'/'+_settings.REPONAME+'/actions/workflows/sh-generator-windows.yml/dispatches'
+
+    inputs_raw = {
+        "server":server,
+        "key":key,
+        "apiServer":apiServer,
+        "custom":encodedCustom,
+        "uuid":myuuid,
+        "iconlink_url":iconlink_url,
+        "iconlink_uuid":iconlink_uuid,
+        "iconlink_file":iconlink_file,
+        "logolink_url":logolink_url,
+        "logolink_uuid":logolink_uuid,
+        "logolink_file":logolink_file,
+        "privacylink_url":privacylink_url,
+        "privacylink_uuid":privacylink_uuid,
+        "privacylink_file":privacylink_file,
+        "appname":appname,
+        "genurl":_settings.GENURL,
+        "urlLink":urlLink,
+        "downloadLink":downloadLink,
+        "delayFix": 'true' if delayFix else 'false',
+        "rdgen":'true',
+        "xOffline": 'true' if xOffline else 'false',
+        "removeNewVersionNotif": 'true' if removeNewVersionNotif else 'false',
+        "compname": compname,
+        "androidappid":androidappid,
+        "filename":filename
+    }
+
+    temp_json_path = f"data_{uuid.uuid4()}.json"
+    zip_filename = f"secrets_{uuid.uuid4()}.zip"
+    zip_path = "temp_zips/%s" % (zip_filename)
+    Path("temp_zips").mkdir(parents=True, exist_ok=True)
+
+    with open(temp_json_path, "w") as f:
+        json.dump(inputs_raw, f)
+
+    with pyzipper.AESZipFile(zip_path, 'w', compression=pyzipper.ZIP_LZMA, encryption=pyzipper.WZ_AES) as zf:
+        zf.setpassword(_settings.ZIP_PASSWORD.encode())
+        zf.write(temp_json_path, arcname="secrets.json")
+
+    if os.path.exists(temp_json_path):
+        os.remove(temp_json_path)
+
+    zipJson = {}
+    zipJson['url'] = full_url
+    zipJson['file'] = zip_filename
+
+    zip_url = json.dumps(zipJson)
+
+    data = {
+        "ref":_settings.GHBRANCH,
+        "inputs":{
+            "version":version,
+            "zip_url":zip_url
+        },
+        "return_run_details": True
+    } 
+    headers = {
+        'Accept':  'application/vnd.github+json',
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer '+_settings.GHBEARER,
+        'X-GitHub-Api-Version': '2026-03-10'
+    }
+    new_github_run = GithubRun(
+        uuid=myuuid,
+        status="Starting generator...please wait"
+    )
+    try:
+        response = requests.post(url, json=data, headers=headers)
+        if response.status_code == 204 or response.status_code == 200:
+            github_data = response.json()
+            print(github_data)
+            new_github_run.github_run_id = github_data.get('workflow_run_id')
+            new_github_run.status = "in_progress"
+            new_github_run.save()
+
+            return {
+                "success": True,
+                "uuid": myuuid,
+                "filename": filename,
+                "platform": platform,
+                "log_url": github_data.get('html_url')
+            }
+        else:
+            return {
+                "success": False,
+                "error": "GitHub rejected the start request",
+                "status_code": 500
+            }
+    except Exception as e:
+        return {
+            "success": False,
+            "error": f"Connection error: {str(e)}",
+            "status_code": 500
+        }
 
 
-from django.shortcuts import render, get_object_or_404
-from django.db.models import Q
+def _get_run_status(uuid_val):
+    """
+    Core status-check logic shared by web form and JSON API.
 
-def check_for_file(request):
-    filename = request.GET.get('filename')
-    uuid = request.GET.get('uuid')
-    platform = request.GET.get('platform')
-    gh_run = get_object_or_404(GithubRun, uuid=uuid)
+    Args:
+        uuid_val: the UUID string of the generation run
+
+    Returns:
+        dict with 'found', 'status', 'github_log_url', and optionally 'gh_run'.
+        If not found, 'found' is False.
+    """
+    try:
+        gh_run = GithubRun.objects.get(uuid=uuid_val)
+    except GithubRun.DoesNotExist:
+        return {"found": False}
+
     github_log_url = f"https://github.com/{_settings.GHUSER}/{_settings.REPONAME}/actions/runs/{gh_run.github_run_id}"
 
     if gh_run.status not in ['success', 'failure', 'cancelled', 'timed_out', 'skipped']:
@@ -367,7 +368,51 @@ def check_for_file(request):
                     gh_run.save()
         except Exception as e:
             print(f"Error checking GitHub: {e}")
-    
+
+    return {
+        "found": True,
+        "status": gh_run.status,
+        "github_log_url": github_log_url,
+        "gh_run": gh_run
+    }
+
+
+def generator_view(request):
+    if request.method == 'POST':
+        form = GenerateForm(request.POST, request.FILES)
+        if form.is_valid():
+            params = form.cleaned_data
+            full_url = f"{_settings.PROTOCOL}://{request.get_host()}" if _settings.GENURL else f"{_settings.PROTOCOL}://{request.get_host()}"
+            result = generate_custom_client(params, full_url)
+            if result['success']:
+                return render(request, 'waiting.html', {
+                    'filename': result['filename'],
+                    'uuid': result['uuid'],
+                    'status': "Starting generator...please wait",
+                    'platform': result['platform'],
+                    'log_url': result['log_url']
+                })
+            else:
+                return JsonResponse({"error": result['error']}, status=result.get('status_code', 500))
+    else:
+        form = GenerateForm()
+    #return render(request, 'maintenance.html')
+    return render(request, 'generator.html', {'form': form})
+
+
+def check_for_file(request):
+    filename = request.GET.get('filename')
+    uuid = request.GET.get('uuid')
+    platform = request.GET.get('platform')
+
+    result = _get_run_status(uuid)
+    if not result['found']:
+        from django.http import Http404
+        raise Http404("Run not found")
+
+    gh_run = result['gh_run']
+    github_log_url = result['github_log_url']
+
     if gh_run.status == "success":
         return render(request, 'generated.html', {
             'filename': filename, 


### PR DESCRIPTION
## Summary

- Add `POST /api/generate` endpoint that accepts JSON body with all client configuration parameters and returns JSON response (uuid, filename, platform, log_url, status_url)
- Add `GET /api/status` endpoint that queries generation status by UUID and returns JSON response (status, uuid, log_url, filename, platform)
- Extract `generate_custom_client(params, full_url)` from `generator_view` to share core business logic between web form and API
- Extract `_get_run_status(uuid)` from `check_for_file` to share status checking logic
- New file `rdgenerator/api_views.py` with `validate_generate_params`, `api_generate`, `api_status`
- Existing web form interface remains completely unchanged

## API Usage

### POST /api/generate

```bash
curl -X POST http://localhost:8000/api/generate \
  -H "Content-Type: application/json" \
  -d '{
    "platform": "windows",
    "version": "1.4.9",
    "exename": "myapp",
    "serverIP": "rs-ny.rustdesk.com",
    "key": "OeVuKk5nlHiXp+APNn0Y3pC1Iwpwn44JGqrQCsWqmBw=",
    "iconbase64": "data:image/png;base64,..."
  }'
```

### GET /api/status

```bash
curl "http://localhost:8000/api/status?uuid=<uuid>&platform=windows&filename=myapp"
```

## Test plan

- [x] Verify `POST /api/generate` accepts valid JSON and returns success response
- [x] Verify `POST /api/generate` returns 400 for invalid parameters
- [x] Verify `GET /api/status` returns correct status JSON
- [x] Verify `GET /api/status` returns 404 for unknown UUID
- [x] Verify existing web form (`/generator`) still works correctly
- [x] Verify `check_for_file` still renders HTML correctly

## Issue
#272 