### PR TITLE
fix(configs): reconcile last-build status live on the landing page

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,11 +7,20 @@ on:
       - master
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Publish to this repo's GitHub Container Registry namespace with the built-in
+    # token — no Docker Hub account or secrets to configure.
+    permissions:
+      contents: read
+      packages: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: set docker image tag
         run: |
           if [[ "${{ github.ref }}" == "refs/heads/dev" ]]; then
@@ -27,12 +36,13 @@ jobs:
             echo "CREATE_IMAGE=false" >> "$GITHUB_ENV"
           fi
 
-      - name: Login to Docker Hub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         if: env.CREATE_IMAGE == 'true'
         with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -42,5 +52,6 @@ jobs:
         uses: docker/build-push-action@v6
         if: env.CREATE_IMAGE == 'true'
         with:
+          context: .
           push: true
-          tags: ${{ vars.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:${{ env.IMAGE_TAG }}
+          tags: ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/generator-windows.yml
+++ b/.github/workflows/generator-windows.yml
@@ -433,9 +433,23 @@ jobs:
         env:
           VCPKG_DEFAULT_HOST_TRIPLET: ${{ matrix.job.vcpkg-triplet }}
         run: |
+          # Release-only overlay triplet. vcpkg builds Release AND Debug for every
+          # port by default, but RustDesk links Release throughout, so the Debug
+          # half (most expensively, ffmpeg) is built and thrown away. Skipping it
+          # roughly halves from-source vcpkg time and binary-cache size.
+          # Generated inline because by this point the workspace holds the rustdesk
+          # checkout, not this repo, so a committed file here would be gone.
+          mkdir -p ./vcpkg-triplets
+          cat > ./vcpkg-triplets/${{ matrix.job.vcpkg-triplet }}.cmake <<'EOF'
+          set(VCPKG_TARGET_ARCHITECTURE x64)
+          set(VCPKG_CRT_LINKAGE static)
+          set(VCPKG_LIBRARY_LINKAGE static)
+          set(VCPKG_BUILD_TYPE release)
+          EOF
           if ! $VCPKG_ROOT/vcpkg \
             install \
             --triplet ${{ matrix.job.vcpkg-triplet }} \
+            --overlay-triplets="$(pwd)/vcpkg-triplets" \
             --x-install-root="$VCPKG_ROOT/installed"; then
             find "${VCPKG_ROOT}/" -name "*.log" | while read -r _1; do
               echo "$_1:"

--- a/.github/workflows/generator-windows.yml
+++ b/.github/workflows/generator-windows.yml
@@ -27,7 +27,10 @@ env:
   # for arm64 linux because official Dart SDK does not work
   FLUTTER_ELINUX_VERSION: "3.16.9"
   TAG_NAME: "${{ inputs.upload-tag }}"
-  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+  # NuGet (GitHub Packages) is a durable binary cache that is NOT subject to the
+  # 10 GB Actions-cache LRU eviction that was forcing ffmpeg to rebuild from
+  # source (~14 min). x-gha is kept as a fallback so behaviour never regresses.
+  VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite;x-gha,readwrite"
   # vcpkg version: 2024.07.12
   VCPKG_COMMIT_ID: "120deac3062162151622ca4860575a33844ba10b"
   ARMV7_VCPKG_COMMIT_ID: "6f29f12e82a8293156836ad81cc9bf5af41fe836"
@@ -69,6 +72,13 @@ jobs:
     name: Build Windows
     needs: [build-RustDeskTempTopMostWindow, generate-bridge, setup]
     runs-on: ${{ matrix.job.os }}
+    # packages: write lets vcpkg push/pull its binary cache to the GitHub
+    # Packages NuGet feed. contents/actions:read preserve checkout and
+    # download-artifact, which no longer inherit write from the default token.
+    permissions:
+      contents: read
+      packages: write
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -328,6 +338,8 @@ jobs:
         uses: KyleMayes/install-llvm-action@v1
         with:
           version: ${{ env.LLVM_VERSION }}
+          # Cache the LLVM download instead of re-fetching it every run.
+          cached: true
 
       - name: Install flutter
         uses: subosito/flutter-action@v2.12.0 #https://github.com/subosito/flutter-action/issues/277
@@ -367,7 +379,25 @@ jobs:
         with:
           vcpkgDirectory: C:\vcpkg
           vcpkgGitCommitId: ${{ env.VCPKG_COMMIT_ID }}
-          doNotCache: false
+          # The built packages are cached via VCPKG_BINARY_SOURCES (NuGet + x-gha),
+          # so caching the vcpkg tree here too just competes for the 10 GB
+          # Actions-cache budget and can evict the Rust cache. Let it re-bootstrap.
+          doNotCache: true
+
+      - name: Authenticate vcpkg NuGet binary cache (GitHub Packages)
+        # Register the durable NuGet feed used by VCPKG_BINARY_SOURCES above.
+        # Non-fatal on purpose: if auth fails, vcpkg silently falls back to the
+        # x-gha cache and the build behaves exactly as it did before.
+        continue-on-error: true
+        shell: pwsh
+        env:
+          FEED_URL: "https://nuget.pkg.github.com/parkview-gh/index.json"
+          GH_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $nuget = & "$env:VCPKG_ROOT\vcpkg.exe" fetch nuget | Select-Object -Last 1
+          & $nuget sources add -Source "$env:FEED_URL" -Name GitHub `
+            -Username "parkview-gh" -Password "$env:GH_PACKAGES_TOKEN" -StorePasswordInClearText
+          & $nuget setapikey "$env:GH_PACKAGES_TOKEN" -Source "$env:FEED_URL"
 
       - name: Install vcpkg dependencies
         env:

--- a/.github/workflows/generator-windows.yml
+++ b/.github/workflows/generator-windows.yml
@@ -564,6 +564,24 @@ jobs:
           command: |
             Invoke-WebRequest -Uri ${{ env.logolink_url }}/get_png?filename=${{ env.logolink_file }}"&"uuid=${{ env.logolink_uuid }} -OutFile ./rustdesk/data/flutter_assets/assets/logo.png
 
+      - name: verify logo is in the asset manifest
+        if: ${{ env.logolink_url != 'false' }}
+        shell: pwsh
+        run: |
+          # Proof the custom logo actually got bundled: RustDesk loads it via
+          # rootBundle.load, which needs it in AssetManifest.bin - not just on disk
+          # (Watchtower LT-158). Fail loudly instead of shipping an invisible logo.
+          $manifest = "./rustdesk/data/flutter_assets/AssetManifest.bin"
+          $onDisk = Test-Path "./rustdesk/data/flutter_assets/assets/logo.png"
+          $inManifest = Select-String -Path $manifest -Pattern "logo" -SimpleMatch -Quiet
+          Write-Host "logo.png on disk:          $onDisk"
+          Write-Host "logo in AssetManifest.bin: $inManifest"
+          if (-not $inManifest) {
+            Write-Error "Custom logo requested but NOT in AssetManifest.bin - it will not render. (LT-158)"
+            exit 1
+          }
+          Write-Host "OK: custom logo is bundled and will render."
+
       - name: find Runner.res
         # Windows: find Runner.res (compiled from ./flutter/windows/runner/Runner.rc), copy to ./Runner.res
         # Runner.rc does not contain actual version, but Runner.res does

--- a/.github/workflows/generator-windows.yml
+++ b/.github/workflows/generator-windows.yml
@@ -491,6 +491,21 @@ jobs:
             Write-Host "Error: printer-adapter folder not found in repository."
           }
 
+      - name: logo asset (pre-build so it is bundled into the manifest)
+        if: ${{ env.logolink_url != 'false' }}
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 15
+          shell: pwsh
+          command: |
+            # Place the logo in the SOURCE assets dir BEFORE the Flutter build so
+            # pubspec (assets: - assets/) globs it into AssetManifest.bin and RustDesk
+            # can load it (loadLogo -> rootBundle.load). The post-build "logo stuff"
+            # step drops it in too late to be manifested (Watchtower LT-158).
+            Invoke-WebRequest -Uri ${{ env.logolink_url }}/get_png?filename=${{ env.logolink_file }}"&"uuid=${{ env.logolink_uuid }} -OutFile ./flutter/assets/logo.png
+
       - name: Build rustdesk
         run: |
           # Windows: build RustDesk

--- a/.github/workflows/generator-windows.yml
+++ b/.github/workflows/generator-windows.yml
@@ -27,10 +27,10 @@ env:
   # for arm64 linux because official Dart SDK does not work
   FLUTTER_ELINUX_VERSION: "3.16.9"
   TAG_NAME: "${{ inputs.upload-tag }}"
-  # NuGet (GitHub Packages) is a durable binary cache that is NOT subject to the
-  # 10 GB Actions-cache LRU eviction that was forcing ffmpeg to rebuild from
-  # source (~14 min). x-gha is kept as a fallback so behaviour never regresses.
-  VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite;x-gha,readwrite"
+  # Durable binary cache on a GitHub Packages NuGet feed. (The old x-gha backend
+  # was removed from vcpkg, so it was a no-op that only printed a warning — and
+  # its absence is why cold builds rebuilt ffmpeg from source for ~14 min.)
+  VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
   # vcpkg version: 2024.07.12
   VCPKG_COMMIT_ID: "120deac3062162151622ca4860575a33844ba10b"
   ARMV7_VCPKG_COMMIT_ID: "6f29f12e82a8293156836ad81cc9bf5af41fe836"
@@ -409,15 +409,15 @@ jobs:
         with:
           vcpkgDirectory: C:\vcpkg
           vcpkgGitCommitId: ${{ env.VCPKG_COMMIT_ID }}
-          # The built packages are cached via VCPKG_BINARY_SOURCES (NuGet + x-gha),
+          # The built packages are cached via VCPKG_BINARY_SOURCES (NuGet feed),
           # so caching the vcpkg tree here too just competes for the 10 GB
           # Actions-cache budget and can evict the Rust cache. Let it re-bootstrap.
           doNotCache: true
 
       - name: Authenticate vcpkg NuGet binary cache (GitHub Packages)
         # Register the durable NuGet feed used by VCPKG_BINARY_SOURCES above.
-        # Non-fatal on purpose: if auth fails, vcpkg silently falls back to the
-        # x-gha cache and the build behaves exactly as it did before.
+        # Non-fatal on purpose: if auth fails, vcpkg builds from source (no cache)
+        # rather than failing the run.
         continue-on-error: true
         shell: pwsh
         env:

--- a/.github/workflows/generator-windows.yml
+++ b/.github/workflows/generator-windows.yml
@@ -214,6 +214,36 @@ jobs:
           sed -i -e 's|reg delete HKEY_CLASSES_ROOT\\\\.{ext} /f|reg delete \\\"HKEY_CLASSES_ROOT\\\\.{ext}\\\" /f|' ./src/platform/windows.rs
           sed -i -e 's|reg delete HKEY_CLASSES_ROOT\\\\{ext} /f|reg delete \\\"HKEY_CLASSES_ROOT\\\\{ext}\\\" /f|' ./src/platform/windows.rs
           
+      - name: Restructure About page (plain copyright, drop slogan)
+        # Watchtower: pull the copyright out of the blue box into the same plain
+        # SelectionArea/Text format as Version/Build/Fingerprint above it, and drop
+        # the "Slogan_tip" line. Runs BEFORE "change company name", which then
+        # renames Purslane -> compname in the copyright text. Regex-based so it does
+        # not depend on exact source indentation.
+        shell: python
+        run: |
+          import re
+          path = "flutter/lib/desktop/pages/desktop_setting_page.dart"
+          with open(path, encoding="utf-8") as f:
+              s = f.read()
+          pattern = re.compile(
+              r"Container\(\s*decoration: const BoxDecoration\(color: Color\(0xFF2c8cff\)\)"
+              r".*?\)\.marginSymmetric\(vertical: 4\.0\)",
+              re.DOTALL,
+          )
+          replacement = (
+              "SelectionArea(\n"
+              "                  child: Text(\n"
+              "                          'Copyright © ${DateTime.now().toString().substring(0, 4)} Purslane Tech Pte. Ltd.')\n"
+              "                      .marginSymmetric(vertical: 4.0))"
+          )
+          s, n = pattern.subn(replacement, s, count=1)
+          if n != 1:
+              raise SystemExit("About page anchor not matched - RustDesk layout changed")
+          with open(path, "w", encoding="utf-8") as f:
+              f.write(s)
+          print("About page restructured: plain copyright, slogan removed")
+
       - name: change company name
         if: env.compname != 'Purslane Ltd'
         continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 db.sqlite3
 gunicorn.conf
 .venv
+builds/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,3 +22,6 @@ services:
       - ./exe:/opt/rdgen/exe
       - ./png:/opt/rdgen/png
       - ./temp_zips:/opt/rdgen/temp_zips
+      # Saved configurations and their builds (the /configs console). One
+      # subdirectory per config; artifacts land in builds/<config>/<timestamp>/.
+      - ./builds:/opt/rdgen/builds

--- a/rdgen/settings.py
+++ b/rdgen/settings.py
@@ -33,6 +33,10 @@ SH_SECRET = os.environ.get('SH_SECRET', 'secret')
 MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 
+# Root of the saved-config / build store (Docker volume mounted at
+# /opt/rdgen/builds; BASE_DIR is /opt/rdgen in the container).
+BUILDS_ROOT = os.environ.get('BUILDS_ROOT', os.path.join(BASE_DIR, 'builds'))
+
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG_ENV = os.environ.get("DEBUG", "False")

--- a/rdgen/urls.py
+++ b/rdgen/urls.py
@@ -19,15 +19,15 @@ import django
 from rdgenerator import views as views
 from rdgenerator import api_views as api_views
 from rdgenerator import config_views as config_views
-from django.views.generic.base import RedirectView
 if django.__version__.split('.')[0]>='4':
     from django.urls import re_path as url
 else:
     from django.conf.urls import  url, include
 
 urlpatterns = [
-    # Landing page is the saved-configs console; the generator lives at /generator.
-    url(r'^$', RedirectView.as_view(url='/configs', permanent=False)),
+    # Landing page renders the saved-configs console directly (not a redirect);
+    # the generator lives at /generator.
+    url(r'^$', config_views.configs_list),
     url(r'^generator',views.generator_view),
     url(r'^check_for_file',views.check_for_file),
     url(r'^download',views.download),

--- a/rdgen/urls.py
+++ b/rdgen/urls.py
@@ -18,6 +18,7 @@ import django
 
 from rdgenerator import views as views
 from rdgenerator import api_views as api_views
+from rdgenerator import config_views as config_views
 if django.__version__.split('.')[0]>='4':
     from django.urls import re_path as url
 else:
@@ -35,6 +36,13 @@ urlpatterns = [
     url(r'^save_custom_client',views.save_custom_client),
     url(r'^get_zip',views.get_zip),
     url(r'^cleanzip',views.cleanup_secrets),
+    # Saved-config console (order matters: specific routes before the list prefix)
+    url(r'^configs/new$', config_views.config_new),
+    url(r'^configs/save$', config_views.config_save),
+    url(r'^configs/(?P<cfg>[0-9a-f-]{36})/edit$', config_views.config_edit),
+    url(r'^configs/(?P<cfg>[0-9a-f-]{36})/duplicate$', config_views.config_duplicate),
+    url(r'^configs/(?P<cfg>[0-9a-f-]{36})/delete$', config_views.config_delete),
+    url(r'^configs/?$', config_views.configs_list),
     # JSON API endpoints
     url(r'^api/generate$',api_views.api_generate),
     url(r'^api/status$',api_views.api_status),

--- a/rdgen/urls.py
+++ b/rdgen/urls.py
@@ -43,6 +43,7 @@ urlpatterns = [
     url(r'^configs/(?P<cfg>[0-9a-f-]{36})/duplicate$', config_views.config_duplicate),
     url(r'^configs/(?P<cfg>[0-9a-f-]{36})/delete$', config_views.config_delete),
     url(r'^configs/(?P<cfg>[0-9a-f-]{36})/build$', config_views.config_build),
+    url(r'^configs/(?P<cfg>[0-9a-f-]{36})/history$', config_views.config_history),
     url(r'^configs/(?P<cfg>[0-9a-f-]{36})/builds/(?P<ts>\d{8}T\d{6}Z(?:-\d+)?)/download$', config_views.config_build_download),
     url(r'^configs/?$', config_views.configs_list),
     # JSON API endpoints

--- a/rdgen/urls.py
+++ b/rdgen/urls.py
@@ -42,6 +42,8 @@ urlpatterns = [
     url(r'^configs/(?P<cfg>[0-9a-f-]{36})/edit$', config_views.config_edit),
     url(r'^configs/(?P<cfg>[0-9a-f-]{36})/duplicate$', config_views.config_duplicate),
     url(r'^configs/(?P<cfg>[0-9a-f-]{36})/delete$', config_views.config_delete),
+    url(r'^configs/(?P<cfg>[0-9a-f-]{36})/build$', config_views.config_build),
+    url(r'^configs/(?P<cfg>[0-9a-f-]{36})/builds/(?P<ts>\d{8}T\d{6}Z(?:-\d+)?)/download$', config_views.config_build_download),
     url(r'^configs/?$', config_views.configs_list),
     # JSON API endpoints
     url(r'^api/generate$',api_views.api_generate),

--- a/rdgen/urls.py
+++ b/rdgen/urls.py
@@ -19,13 +19,15 @@ import django
 from rdgenerator import views as views
 from rdgenerator import api_views as api_views
 from rdgenerator import config_views as config_views
+from django.views.generic.base import RedirectView
 if django.__version__.split('.')[0]>='4':
     from django.urls import re_path as url
 else:
     from django.conf.urls import  url, include
 
 urlpatterns = [
-    url(r'^$',views.generator_view),
+    # Landing page is the saved-configs console; the generator lives at /generator.
+    url(r'^$', RedirectView.as_view(url='/configs', permanent=False)),
     url(r'^generator',views.generator_view),
     url(r'^check_for_file',views.check_for_file),
     url(r'^download',views.download),

--- a/rdgenerator/config_store.py
+++ b/rdgenerator/config_store.py
@@ -170,8 +170,17 @@ def has_asset(cfg, name):
     return os.path.isfile(os.path.join(assets_dir(cfg), f'{name}.png'))
 
 
+def load_asset_b64(cfg, name):
+    """Return a persisted asset as a data-URI base64 string, or None."""
+    path = os.path.join(assets_dir(cfg), f'{name}.png')
+    if not os.path.isfile(path):
+        return None
+    with open(path, 'rb') as f:
+        return 'data:image/png;base64,' + base64.b64encode(f.read()).decode('ascii')
+
+
 def latest_build(cfg):
-    """Newest build.json summary for a config, or None. (Builds arrive in Phase 2.)"""
+    """Newest build.json summary for a config, or None."""
     builds = list_builds(cfg)
     return builds[0] if builds else None
 
@@ -223,3 +232,141 @@ def list_configs():
         })
     rows.sort(key=lambda r: r['updated_at'], reverse=True)
     return rows
+
+
+# --- Builds (Phase 2) -------------------------------------------------------
+#
+# A build is a timestamped subdir of a config. Each carries a build.json and,
+# once the workflow reports back, its artifacts. The workflow only knows the
+# build_uuid (Option A: it POSTs `uuid` unchanged), so build_uuid -> dir is
+# resolved server-side via a small index file, falling back to a scan.
+
+INDEX_DIRNAME = '.index'
+
+
+def new_build_dir(cfg):
+    """Create and return a fresh, unique build timestamp for a config."""
+    base = utc_stamp()
+    ts, n = base, 2
+    while os.path.exists(build_dir(cfg, ts)):
+        ts, n = f'{base}-{n}', n + 1
+    Path(build_dir(cfg, ts)).mkdir(parents=True, exist_ok=True)
+    return ts
+
+
+def _build_json_path(cfg, ts):
+    return os.path.join(build_dir(cfg, ts), 'build.json')
+
+
+def read_build(cfg, ts):
+    path = _build_json_path(cfg, ts)
+    if not os.path.isfile(path):
+        return None
+    with open(path, 'r') as f:
+        return json.load(f)
+
+
+def write_build(cfg, ts, data):
+    Path(build_dir(cfg, ts)).mkdir(parents=True, exist_ok=True)
+    with open(_build_json_path(cfg, ts), 'w') as f:
+        json.dump(data, f, indent=2)
+
+
+def _index_path(build_uuid):
+    # build_uuid is a uuid4 — same shape as a config id.
+    if not is_valid_config_id(build_uuid):
+        raise ValueError(f'invalid build uuid: {build_uuid!r}')
+    return os.path.join(builds_root(), INDEX_DIRNAME, build_uuid)
+
+
+def register_build(build_uuid, cfg, ts):
+    """Record build_uuid -> '<cfg>/<ts>' so callbacks can find the build dir."""
+    Path(os.path.join(builds_root(), INDEX_DIRNAME)).mkdir(parents=True, exist_ok=True)
+    with open(_index_path(build_uuid), 'w') as f:
+        f.write(f'{cfg}/{ts}')
+
+
+def resolve_build(build_uuid):
+    """Return (cfg, ts, abs_dir) for a build_uuid, or None. Index first, then scan."""
+    if not is_valid_config_id(build_uuid):
+        return None
+    idx = _index_path(build_uuid)
+    if os.path.isfile(idx):
+        with open(idx, 'r') as f:
+            cfg, _, ts = f.read().strip().partition('/')
+        if is_valid_config_id(cfg) and is_valid_build_id(ts) and os.path.isdir(build_dir(cfg, ts)):
+            return cfg, ts, build_dir(cfg, ts)
+    # Fallback: scan every build.json for a matching build_uuid.
+    root = builds_root()
+    if not os.path.isdir(root):
+        return None
+    for cfg_entry in os.scandir(root):
+        if not cfg_entry.is_dir() or not is_valid_config_id(cfg_entry.name):
+            continue
+        for b in os.scandir(cfg_entry.path):
+            if not b.is_dir() or not is_valid_build_id(b.name):
+                continue
+            data = read_build(cfg_entry.name, b.name)
+            if data and data.get('build_uuid') == build_uuid:
+                return cfg_entry.name, b.name, b.path
+    return None
+
+
+def start_build(cfg, ts, build_uuid, github_run_id, platform, version):
+    """Mark a build in-progress once its workflow has been dispatched."""
+    now = utc_stamp()
+    write_build(cfg, ts, {
+        'build_uuid': build_uuid,
+        'github_run_id': github_run_id,
+        'status': 'in_progress',
+        'platform': platform,
+        'version': version,
+        'started_at': now,
+        'updated_at': now,
+        'artifacts': [],
+    })
+    register_build(build_uuid, cfg, ts)
+
+
+def fail_build(cfg, ts, error):
+    """Record a build that could not be dispatched."""
+    data = read_build(cfg, ts) or {'artifacts': []}
+    data.update({'status': 'failure', 'error': str(error), 'updated_at': utc_stamp()})
+    write_build(cfg, ts, data)
+
+
+def update_build_status(build_uuid, status):
+    """Update a build's status by build_uuid (called from the /updategh callback)."""
+    resolved = resolve_build(build_uuid)
+    if not resolved:
+        return False
+    cfg, ts, _ = resolved
+    data = read_build(cfg, ts) or {'artifacts': []}
+    data.update({'status': status, 'updated_at': utc_stamp()})
+    write_build(cfg, ts, data)
+    return True
+
+
+def record_artifact(build_uuid, filename):
+    """Append an artifact filename to a build's build.json. Returns the build dir or None."""
+    resolved = resolve_build(build_uuid)
+    if not resolved:
+        return None
+    cfg, ts, bdir = resolved
+    data = read_build(cfg, ts) or {'artifacts': []}
+    artifacts = data.get('artifacts', [])
+    if filename not in artifacts:
+        artifacts.append(filename)
+    data['artifacts'] = artifacts
+    data['updated_at'] = utc_stamp()
+    write_build(cfg, ts, data)
+    return bdir
+
+
+def build_artifact_path(cfg, ts, filename):
+    """Absolute path to an artifact, validated to stay inside the build dir."""
+    bdir = build_dir(cfg, ts)
+    path = os.path.abspath(os.path.join(bdir, filename))
+    if path != os.path.join(bdir, os.path.basename(filename)):
+        raise ValueError(f'artifact escapes build dir: {filename!r}')
+    return path

--- a/rdgenerator/config_store.py
+++ b/rdgenerator/config_store.py
@@ -1,0 +1,225 @@
+"""
+Server-side store for saved generator configs and their builds.
+
+Layout under settings.BUILDS_ROOT (mounted at /opt/rdgen/builds):
+
+    builds/
+      <config-uuid>/
+        config.json                 # saved GenerateForm params (source of truth)
+        assets/                     # persisted icon/logo/privacy PNGs
+          icon.png  logo.png  privacy.png
+        <UTC-timestamp>/            # one dir per build (Phase 2)
+          build.json
+          <artifacts>
+
+Everything here is filesystem-only; there is no database row for a config. The
+config uuid is the stable directory name; each build gets a UTC timestamp
+subdir. Only these two id shapes are ever joined onto the builds root, and every
+join is validated to stay inside it — see is_valid_config_id / is_valid_build_id.
+"""
+import base64
+import json
+import os
+import re
+import shutil
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from django.conf import settings
+
+CONFIG_ID_RE = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$')
+BUILD_ID_RE = re.compile(r'^\d{8}T\d{6}Z(?:-\d+)?$')
+
+# GenerateForm keys that must NOT go into config.json: file objects can't be
+# serialized, and the base64 blobs are persisted as PNG files under assets/.
+_NON_PARAM_FIELDS = {
+    'iconfile', 'logofile', 'privacyfile',
+    'iconbase64', 'logobase64', 'privacybase64',
+}
+
+# Maps the config-store asset name to (upload field, base64 field) on the form.
+ASSETS = {
+    'icon': ('iconfile', 'iconbase64'),
+    'logo': ('logofile', 'logobase64'),
+    'privacy': ('privacyfile', 'privacybase64'),
+}
+
+
+def builds_root():
+    return os.path.abspath(settings.BUILDS_ROOT)
+
+
+def is_valid_config_id(cfg):
+    return isinstance(cfg, str) and bool(CONFIG_ID_RE.match(cfg))
+
+
+def is_valid_build_id(ts):
+    return isinstance(ts, str) and bool(BUILD_ID_RE.match(ts))
+
+
+def new_config_id():
+    return str(uuid.uuid4())
+
+
+def utc_stamp():
+    return datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')
+
+
+def config_dir(cfg):
+    """Absolute path to a config dir, guaranteed to sit inside builds_root."""
+    if not is_valid_config_id(cfg):
+        raise ValueError(f'invalid config id: {cfg!r}')
+    root = builds_root()
+    path = os.path.abspath(os.path.join(root, cfg))
+    if path != os.path.join(root, cfg):
+        raise ValueError(f'config id escapes builds root: {cfg!r}')
+    return path
+
+
+def config_json_path(cfg):
+    return os.path.join(config_dir(cfg), 'config.json')
+
+
+def assets_dir(cfg):
+    return os.path.join(config_dir(cfg), 'assets')
+
+
+def build_dir(cfg, ts):
+    if not is_valid_build_id(ts):
+        raise ValueError(f'invalid build id: {ts!r}')
+    return os.path.join(config_dir(cfg), ts)
+
+
+def exists(cfg):
+    return is_valid_config_id(cfg) and os.path.isfile(config_json_path(cfg))
+
+
+def read_config(cfg):
+    """Return the parsed config.json dict, or None if it doesn't exist."""
+    if not exists(cfg):
+        return None
+    with open(config_json_path(cfg), 'r') as f:
+        return json.load(f)
+
+
+def write_config(cfg, params, note='', created_at=None):
+    """Create or overwrite a config. `params` is JSON-serializable form data."""
+    Path(config_dir(cfg)).mkdir(parents=True, exist_ok=True)
+    now = utc_stamp()
+    record = {
+        'version': 1,
+        'id': cfg,
+        'created_at': created_at or now,
+        'updated_at': now,
+        'note': note or '',
+        'params': {k: v for k, v in params.items() if k not in _NON_PARAM_FIELDS},
+    }
+    with open(config_json_path(cfg), 'w') as f:
+        json.dump(record, f, indent=2)
+    return record
+
+
+def delete_config(cfg):
+    path = config_dir(cfg)
+    if os.path.isdir(path):
+        shutil.rmtree(path)
+
+
+def duplicate_config(cfg):
+    """Copy an existing config dir (config + assets, not builds) to a new id."""
+    src = read_config(cfg)
+    if src is None:
+        return None
+    new_id = new_config_id()
+    Path(config_dir(new_id)).mkdir(parents=True, exist_ok=True)
+    # Copy persisted assets, if any.
+    src_assets = assets_dir(cfg)
+    if os.path.isdir(src_assets):
+        shutil.copytree(src_assets, assets_dir(new_id))
+    params = dict(src.get('params', {}))
+    name = params.get('exename', '')
+    if name:
+        params['exename'] = f'{name}-copy'
+    write_config(new_id, params, note=src.get('note', ''))
+    return new_id
+
+
+def save_asset_from_upload(cfg, name, django_file):
+    """Persist an uploaded PNG (icon/logo/privacy) into assets/."""
+    Path(assets_dir(cfg)).mkdir(parents=True, exist_ok=True)
+    dest = os.path.join(assets_dir(cfg), f'{name}.png')
+    with open(dest, 'wb+') as f:
+        for chunk in django_file.chunks():
+            f.write(chunk)
+
+
+def save_asset_from_b64(cfg, name, data):
+    """Persist a base64 data URI (or bare base64) PNG into assets/."""
+    if not data:
+        return
+    if ';base64,' in data:
+        data = data.split(';base64,', 1)[1]
+    Path(assets_dir(cfg)).mkdir(parents=True, exist_ok=True)
+    dest = os.path.join(assets_dir(cfg), f'{name}.png')
+    with open(dest, 'wb+') as f:
+        f.write(base64.b64decode(data))
+
+
+def has_asset(cfg, name):
+    return os.path.isfile(os.path.join(assets_dir(cfg), f'{name}.png'))
+
+
+def latest_build(cfg):
+    """Newest build.json summary for a config, or None. (Builds arrive in Phase 2.)"""
+    builds = list_builds(cfg)
+    return builds[0] if builds else None
+
+
+def list_builds(cfg):
+    """All builds for a config, newest first. Reads each build.json if present."""
+    cdir = config_dir(cfg)
+    if not os.path.isdir(cdir):
+        return []
+    out = []
+    for entry in os.scandir(cdir):
+        if not entry.is_dir() or not is_valid_build_id(entry.name):
+            continue
+        summary = {'timestamp': entry.name, 'status': 'unknown', 'artifacts': []}
+        bj = os.path.join(entry.path, 'build.json')
+        if os.path.isfile(bj):
+            try:
+                with open(bj, 'r') as f:
+                    summary.update(json.load(f))
+            except (OSError, ValueError):
+                pass
+        out.append(summary)
+    out.sort(key=lambda b: b['timestamp'], reverse=True)
+    return out
+
+
+def list_configs():
+    """All saved configs as table rows, newest-updated first."""
+    root = builds_root()
+    if not os.path.isdir(root):
+        return []
+    rows = []
+    for entry in os.scandir(root):
+        if not entry.is_dir() or not is_valid_config_id(entry.name):
+            continue
+        record = read_config(entry.name)
+        if record is None:
+            continue
+        params = record.get('params', {})
+        last = latest_build(entry.name)
+        rows.append({
+            'id': entry.name,
+            'name': params.get('exename', '(unnamed)'),
+            'appname': params.get('appname') or 'rustdesk',
+            'platform': params.get('platform', ''),
+            'note': record.get('note', ''),
+            'updated_at': record.get('updated_at', ''),
+            'last_build': last,
+        })
+    rows.sort(key=lambda r: r['updated_at'], reverse=True)
+    return rows

--- a/rdgenerator/config_store.py
+++ b/rdgenerator/config_store.py
@@ -179,10 +179,22 @@ def load_asset_b64(cfg, name):
         return 'data:image/png;base64,' + base64.b64encode(f.read()).decode('ascii')
 
 
+def github_run_url(run_id):
+    """URL of a GitHub Actions run for this repo, or None."""
+    if not run_id:
+        return None
+    return (f"https://github.com/{settings.GHUSER}/"
+            f"{settings.REPONAME}/actions/runs/{run_id}")
+
+
 def latest_build(cfg):
-    """Newest build.json summary for a config, or None."""
+    """Newest build.json summary for a config, or None. Includes log_url."""
     builds = list_builds(cfg)
-    return builds[0] if builds else None
+    if not builds:
+        return None
+    last = builds[0]
+    last['log_url'] = github_run_url(last.get('github_run_id'))
+    return last
 
 
 def list_builds(cfg):

--- a/rdgenerator/config_views.py
+++ b/rdgenerator/config_views.py
@@ -8,12 +8,15 @@ config CRUD + table. It reuses the existing GenerateForm and generator.html
 import os
 
 from django.conf import settings
-from django.http import Http404, HttpResponse, HttpResponseBadRequest
+from django.http import Http404, HttpResponse, HttpResponseBadRequest, JsonResponse
 from django.shortcuts import redirect, render
 
 from . import config_store as store
 from .forms import GenerateForm
-from .views import generate_custom_client
+from .views import generate_custom_client, _get_run_status
+
+# Statuses GitHub won't change again — no need to re-poll.
+TERMINAL_STATUSES = {'success', 'failure', 'cancelled', 'timed_out', 'skipped'}
 
 
 def _persist_assets(cfg, form, request):
@@ -121,6 +124,42 @@ def config_build(request, cfg):
     if not result.get('success'):
         store.fail_build(cfg, ts, result.get('error', 'dispatch failed'))
     return redirect('/configs')
+
+
+def config_history(request, cfg):
+    """JSON list of a config's builds (current + previous), newest first.
+
+    Non-terminal builds are refreshed from GitHub (via the shared GithubRun
+    status check) and the fresh status mirrored back onto build.json.
+    """
+    if store.read_config(cfg) is None:
+        raise Http404('Config not found')
+
+    builds = []
+    for b in store.list_builds(cfg):
+        status = b.get('status', 'unknown')
+        build_uuid = b.get('build_uuid')
+        run_id = b.get('github_run_id')
+        if build_uuid and status not in TERMINAL_STATUSES:
+            info = _get_run_status(build_uuid)
+            if info.get('found'):
+                status = info['status']
+                store.update_build_status(build_uuid, status)
+        log_url = None
+        if run_id:
+            log_url = (f"https://github.com/{settings.GHUSER}/"
+                       f"{settings.REPONAME}/actions/runs/{run_id}")
+        builds.append({
+            'timestamp': b.get('timestamp'),
+            'status': status,
+            'platform': b.get('platform', ''),
+            'version': b.get('version', ''),
+            'artifacts': b.get('artifacts', []),
+            'started_at': b.get('started_at', ''),
+            'error': b.get('error', ''),
+            'log_url': log_url,
+        })
+    return JsonResponse({'builds': builds})
 
 
 def config_build_download(request, cfg, ts):

--- a/rdgenerator/config_views.py
+++ b/rdgenerator/config_views.py
@@ -1,0 +1,96 @@
+"""
+Views for the saved-config console: list, create, edit, duplicate, delete.
+
+Building a config and its history arrive in later phases; this module is the
+config CRUD + table. It reuses the existing GenerateForm and generator.html
+(rendered in "save mode") so the editor UI stays a single source of truth.
+"""
+from django.http import Http404, HttpResponseBadRequest
+from django.shortcuts import redirect, render
+
+from . import config_store as store
+from .forms import GenerateForm
+
+
+def _persist_assets(cfg, form, request):
+    """Write any icon/logo/privacy image supplied on this save into assets/."""
+    for name, (upload_field, b64_field) in store.ASSETS.items():
+        uploaded = request.FILES.get(upload_field)
+        if uploaded:
+            store.save_asset_from_upload(cfg, name, uploaded)
+            continue
+        b64 = form.cleaned_data.get(b64_field)
+        if b64:
+            store.save_asset_from_b64(cfg, name, b64)
+
+
+def configs_list(request):
+    return render(request, 'configs_list.html', {'configs': store.list_configs()})
+
+
+def config_new(request):
+    return render(request, 'generator.html', {
+        'form': GenerateForm(),
+        'save_mode': True,
+        'config_id': '',
+        'note': '',
+    })
+
+
+def config_edit(request, cfg):
+    record = store.read_config(cfg)
+    if record is None:
+        raise Http404('Config not found')
+    return render(request, 'generator.html', {
+        'form': GenerateForm(initial=record.get('params', {})),
+        'save_mode': True,
+        'config_id': cfg,
+        'note': record.get('note', ''),
+    })
+
+
+def config_save(request):
+    if request.method != 'POST':
+        return HttpResponseBadRequest('POST required')
+
+    cfg = request.POST.get('config_id', '').strip()
+    if cfg and not store.is_valid_config_id(cfg):
+        return HttpResponseBadRequest('Invalid config id')
+
+    form = GenerateForm(request.POST, request.FILES)
+    if not form.is_valid():
+        return render(request, 'generator.html', {
+            'form': form,
+            'save_mode': True,
+            'config_id': cfg,
+            'note': request.POST.get('note', ''),
+        })
+
+    created_at = None
+    if cfg:
+        existing = store.read_config(cfg)
+        created_at = existing.get('created_at') if existing else None
+    else:
+        cfg = store.new_config_id()
+
+    store.write_config(cfg, form.cleaned_data,
+                       note=request.POST.get('note', ''), created_at=created_at)
+    _persist_assets(cfg, form, request)
+    return redirect('/configs')
+
+
+def config_duplicate(request, cfg):
+    if request.method != 'POST':
+        return HttpResponseBadRequest('POST required')
+    if store.duplicate_config(cfg) is None:
+        raise Http404('Config not found')
+    return redirect('/configs')
+
+
+def config_delete(request, cfg):
+    if request.method != 'POST':
+        return HttpResponseBadRequest('POST required')
+    if not store.exists(cfg):
+        raise Http404('Config not found')
+    store.delete_config(cfg)
+    return redirect('/configs')

--- a/rdgenerator/config_views.py
+++ b/rdgenerator/config_views.py
@@ -31,8 +31,30 @@ def _persist_assets(cfg, form, request):
             store.save_asset_from_b64(cfg, name, b64)
 
 
+def _reconcile_last_build(row):
+    """Refresh a config row's last_build status from GitHub if it's non-terminal.
+
+    Mirrors the check config_history already does per-build: the landing page
+    otherwise only shows a stale 'in_progress' until something else (like
+    opening History) happens to poll GitHub and write the real status back.
+    """
+    last = row.get('last_build')
+    if not last:
+        return
+    build_uuid = last.get('build_uuid')
+    if not build_uuid or last.get('status') in TERMINAL_STATUSES:
+        return
+    info = _get_run_status(build_uuid)
+    if info.get('found'):
+        store.update_build_status(build_uuid, info['status'])
+        last['status'] = info['status']
+
+
 def configs_list(request):
-    return render(request, 'configs_list.html', {'configs': store.list_configs()})
+    configs = store.list_configs()
+    for row in configs:
+        _reconcile_last_build(row)
+    return render(request, 'configs_list.html', {'configs': configs})
 
 
 def config_new(request):

--- a/rdgenerator/config_views.py
+++ b/rdgenerator/config_views.py
@@ -48,8 +48,16 @@ def config_edit(request, cfg):
     record = store.read_config(cfg)
     if record is None:
         raise Http404('Config not found')
+    initial = dict(record.get('params', {}))
+    # Surface persisted images as base64 so they display and round-trip on the
+    # next save (params intentionally omits the image blobs; the PNGs live in
+    # assets/). Without this the edit form shows blank image fields.
+    for _name, (_upload_field, b64_field) in store.ASSETS.items():
+        b64 = store.load_asset_b64(cfg, _name)
+        if b64:
+            initial[b64_field] = b64
     return render(request, 'generator.html', {
-        'form': GenerateForm(initial=record.get('params', {})),
+        'form': GenerateForm(initial=initial),
         'save_mode': True,
         'config_id': cfg,
         'note': record.get('note', ''),

--- a/rdgenerator/config_views.py
+++ b/rdgenerator/config_views.py
@@ -145,10 +145,7 @@ def config_history(request, cfg):
             if info.get('found'):
                 status = info['status']
                 store.update_build_status(build_uuid, status)
-        log_url = None
-        if run_id:
-            log_url = (f"https://github.com/{settings.GHUSER}/"
-                       f"{settings.REPONAME}/actions/runs/{run_id}")
+        log_url = store.github_run_url(run_id)
         builds.append({
             'timestamp': b.get('timestamp'),
             'status': status,

--- a/rdgenerator/config_views.py
+++ b/rdgenerator/config_views.py
@@ -5,11 +5,15 @@ Building a config and its history arrive in later phases; this module is the
 config CRUD + table. It reuses the existing GenerateForm and generator.html
 (rendered in "save mode") so the editor UI stays a single source of truth.
 """
-from django.http import Http404, HttpResponseBadRequest
+import os
+
+from django.conf import settings
+from django.http import Http404, HttpResponse, HttpResponseBadRequest
 from django.shortcuts import redirect, render
 
 from . import config_store as store
 from .forms import GenerateForm
+from .views import generate_custom_client
 
 
 def _persist_assets(cfg, form, request):
@@ -94,3 +98,47 @@ def config_delete(request, cfg):
         raise Http404('Config not found')
     store.delete_config(cfg)
     return redirect('/configs')
+
+
+def config_build(request, cfg):
+    """Kick off a build for a saved config into builds/<cfg>/<timestamp>/."""
+    if request.method != 'POST':
+        return HttpResponseBadRequest('POST required')
+    record = store.read_config(cfg)
+    if record is None:
+        raise Http404('Config not found')
+
+    params = dict(record.get('params', {}))
+    # Feed persisted images to the generator as base64 (it re-uploads them).
+    for name, (_upload_field, b64_field) in store.ASSETS.items():
+        b64 = store.load_asset_b64(cfg, name)
+        if b64:
+            params[b64_field] = b64
+
+    ts = store.new_build_dir(cfg)
+    full_url = f"{settings.PROTOCOL}://{request.get_host()}"
+    result = generate_custom_client(params, full_url, dest=f'{cfg}/{ts}')
+    if not result.get('success'):
+        store.fail_build(cfg, ts, result.get('error', 'dispatch failed'))
+    return redirect('/configs')
+
+
+def config_build_download(request, cfg, ts):
+    """Download a single artifact from builds/<cfg>/<ts>/."""
+    if not (store.is_valid_config_id(cfg) and store.is_valid_build_id(ts)):
+        raise Http404('Not found')
+    filename = request.GET.get('file', '')
+    if not filename:
+        return HttpResponseBadRequest('Missing file')
+    try:
+        path = store.build_artifact_path(cfg, ts, filename)
+    except ValueError:
+        raise Http404('Not found')
+    if not os.path.isfile(path):
+        raise Http404('Not found')
+    with open(path, 'rb') as f:
+        content = f.read()
+    return HttpResponse(content, headers={
+        'Content-Type': 'application/octet-stream',
+        'Content-Disposition': f'attachment; filename="{os.path.basename(path)}"',
+    })

--- a/rdgenerator/forms.py
+++ b/rdgenerator/forms.py
@@ -25,6 +25,10 @@ class GenerateForm(forms.Form):
         ('settingsY', 'No, enable settings'),
         ('settingsN', 'Yes, DISABLE settings')
     ], initial='settingsY')
+    account = forms.ChoiceField(label="Disable Account", choices=[
+        ('accountY', 'No, enable account'),
+        ('accountN', 'Yes, DISABLE account')
+    ], initial='accountY')
     androidappid = forms.CharField(label="Custom Android App ID (replaces 'com.carriez.flutter_hbb')", required=False)
 
     #Custom Server

--- a/rdgenerator/templates/configs_list.html
+++ b/rdgenerator/templates/configs_list.html
@@ -56,7 +56,8 @@
         .modal-body { padding: 8px 20px 20px; }
         .modal-body table { border-radius: 0; }
         .modal-body td, .modal-body th { padding: 10px 12px; font-size: 0.9em; }
-        .status { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 0.8em; text-transform: capitalize; }
+        .status { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 0.8em; text-transform: capitalize; text-decoration: none; }
+        a.status:hover { filter: brightness(1.2); }
         .status.success { background: #113d1f; color: #6ee7a0; }
         .status.failure, .status.cancelled, .status.timed_out { background: #3d1414; color: #ff8a8a; }
         .status.in_progress, .status.unknown, .status.skipped { background: #33321a; color: #e6d76a; }
@@ -90,8 +91,12 @@
                     <td><span class="app"><i class="fab fa-windows"></i> {{ c.appname }}</span></td>
                     <td>
                         {% if c.last_build %}
-                            <span class="status-badge">{{ c.last_build.status }}
-                                <span class="muted">· {{ c.last_build.timestamp }}</span></span>
+                            {% if c.last_build.log_url %}
+                                <a class="status {{ c.last_build.status }}" href="{{ c.last_build.log_url }}" target="_blank" title="View workflow run">{{ c.last_build.status }}</a>
+                            {% else %}
+                                <span class="status {{ c.last_build.status }}">{{ c.last_build.status }}</span>
+                            {% endif %}
+                            <span class="muted">· {{ c.last_build.timestamp }}</span>
                         {% else %}
                             <span class="muted">—</span>
                         {% endif %}

--- a/rdgenerator/templates/configs_list.html
+++ b/rdgenerator/templates/configs_list.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>RustDesk Saved Configurations</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Roboto', sans-serif;
+            background-color: #000;
+            color: #e0e0e0;
+            margin: 0;
+            padding: 20px;
+        }
+        .wrap { max-width: 1200px; margin: 0 auto; }
+        .topbar { display: flex; align-items: center; justify-content: space-between; margin-bottom: 20px; }
+        h1 { color: #fff; font-size: 1.4em; margin: 0; }
+        a.button, button.button {
+            background-color: #0077ff; color: #fff; border: none;
+            padding: 10px 18px; border-radius: 4px; cursor: pointer;
+            text-decoration: none; font-size: 0.95em; display: inline-flex; align-items: center; gap: 6px;
+        }
+        a.button:hover, button.button:hover { background-color: #0066cc; }
+        table { width: 100%; border-collapse: collapse; background-color: #111; border-radius: 8px; overflow: hidden; }
+        th, td { text-align: left; padding: 14px 16px; border-bottom: 1px solid #222; }
+        th { color: #bbb; font-weight: 700; font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.5px; }
+        td .name { color: #4d9fff; font-weight: 700; }
+        td .app { color: #ddd; }
+        .muted { color: #777; }
+        .actions { white-space: nowrap; }
+        .actions form { display: inline; margin: 0; }
+        .actions a, .actions button {
+            background: none; border: none; color: #4d9fff; cursor: pointer;
+            font-size: 0.95em; padding: 0 6px; text-decoration: none;
+        }
+        .actions a:hover, .actions button:hover { text-decoration: underline; }
+        .actions .danger { color: #ff5c5c; }
+        .actions .disabled { color: #555; cursor: not-allowed; }
+        .status-badge { font-size: 0.85em; color: #ccc; }
+        .empty { text-align: center; padding: 60px 20px; color: #777; }
+    </style>
+</head>
+<body>
+    <div class="wrap">
+        <div class="topbar">
+            <h1><i class="fas fa-cogs"></i> Saved Configurations</h1>
+            <a class="button" href="/configs/new"><i class="fas fa-plus"></i> Create</a>
+        </div>
+
+        {% if configs %}
+        <table>
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Application name</th>
+                    <th>Last build</th>
+                    <th>Note</th>
+                    <th>Action</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for c in configs %}
+                <tr>
+                    <td><span class="name">{{ c.name }}</span></td>
+                    <td><span class="app"><i class="fab fa-windows"></i> {{ c.appname }}</span></td>
+                    <td>
+                        {% if c.last_build %}
+                            <span class="status-badge">{{ c.last_build.status }}
+                                <span class="muted">· {{ c.last_build.timestamp }}</span></span>
+                        {% else %}
+                            <span class="muted">—</span>
+                        {% endif %}
+                    </td>
+                    <td>{% if c.note %}{{ c.note }}{% else %}<span class="muted">-</span>{% endif %}</td>
+                    <td class="actions">
+                        <a href="/configs/{{ c.id }}/edit"><i class="fas fa-pen"></i> Edit</a>
+                        <form method="post" action="/configs/{{ c.id }}/duplicate">
+                            <button type="submit"><i class="fas fa-copy"></i> Duplicate</button>
+                        </form>
+                        <form method="post" action="/configs/{{ c.id }}/delete"
+                              onsubmit="return confirm('Delete configuration &quot;{{ c.name }}&quot; and all its builds?');">
+                            <button type="submit" class="danger"><i class="fas fa-trash"></i> Delete</button>
+                        </form>
+                        <a class="disabled" title="Available once the build phase lands"><i class="fas fa-rocket"></i> Build</a>
+                        <a class="disabled" title="Available once the build phase lands"><i class="fas fa-clock-rotate-left"></i> History</a>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <div class="empty">
+            <p>No saved configurations yet.</p>
+            <a class="button" href="/configs/new"><i class="fas fa-plus"></i> Create your first configuration</a>
+        </div>
+        {% endif %}
+    </div>
+</body>
+</html>

--- a/rdgenerator/templates/configs_list.html
+++ b/rdgenerator/templates/configs_list.html
@@ -83,8 +83,10 @@
                               onsubmit="return confirm('Delete configuration &quot;{{ c.name }}&quot; and all its builds?');">
                             <button type="submit" class="danger"><i class="fas fa-trash"></i> Delete</button>
                         </form>
-                        <a class="disabled" title="Available once the build phase lands"><i class="fas fa-rocket"></i> Build</a>
-                        <a class="disabled" title="Available once the build phase lands"><i class="fas fa-clock-rotate-left"></i> History</a>
+                        <form method="post" action="/configs/{{ c.id }}/build">
+                            <button type="submit"><i class="fas fa-rocket"></i> Build</button>
+                        </form>
+                        <a class="disabled" title="Available once the history phase lands"><i class="fas fa-clock-rotate-left"></i> History</a>
                     </td>
                 </tr>
                 {% endfor %}

--- a/rdgenerator/templates/configs_list.html
+++ b/rdgenerator/templates/configs_list.html
@@ -40,6 +40,29 @@
         .actions .disabled { color: #555; cursor: not-allowed; }
         .status-badge { font-size: 0.85em; color: #ccc; }
         .empty { text-align: center; padding: 60px 20px; color: #777; }
+
+        .modal-overlay {
+            display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.7);
+            z-index: 200; align-items: flex-start; justify-content: center; padding: 40px 16px; overflow-y: auto;
+        }
+        .modal-overlay.open { display: flex; }
+        .modal {
+            background: #111; border: 1px solid #222; border-radius: 8px;
+            width: 100%; max-width: 820px; box-shadow: 0 10px 40px rgba(0,0,0,0.6);
+        }
+        .modal-head { display: flex; align-items: center; justify-content: space-between; padding: 16px 20px; border-bottom: 1px solid #222; }
+        .modal-head h2 { margin: 0; font-size: 1.1em; }
+        .modal-close { background: none; border: none; color: #bbb; font-size: 1.3em; cursor: pointer; padding: 0; }
+        .modal-body { padding: 8px 20px 20px; }
+        .modal-body table { border-radius: 0; }
+        .modal-body td, .modal-body th { padding: 10px 12px; font-size: 0.9em; }
+        .status { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 0.8em; text-transform: capitalize; }
+        .status.success { background: #113d1f; color: #6ee7a0; }
+        .status.failure, .status.cancelled, .status.timed_out { background: #3d1414; color: #ff8a8a; }
+        .status.in_progress, .status.unknown, .status.skipped { background: #33321a; color: #e6d76a; }
+        .artifact-link { color: #4d9fff; text-decoration: none; display: inline-block; margin-right: 10px; }
+        .artifact-link:hover { text-decoration: underline; }
+        .loading { text-align: center; color: #888; padding: 30px; }
     </style>
 </head>
 <body>
@@ -86,7 +109,7 @@
                         <form method="post" action="/configs/{{ c.id }}/build">
                             <button type="submit"><i class="fas fa-rocket"></i> Build</button>
                         </form>
-                        <a class="disabled" title="Available once the history phase lands"><i class="fas fa-clock-rotate-left"></i> History</a>
+                        <button type="button" onclick="showHistory('{{ c.id }}', '{{ c.name|escapejs }}')"><i class="fas fa-clock-rotate-left"></i> History</button>
                     </td>
                 </tr>
                 {% endfor %}
@@ -99,5 +122,81 @@
         </div>
         {% endif %}
     </div>
+
+    <div class="modal-overlay" id="historyModal" onclick="if(event.target===this)closeHistory()">
+        <div class="modal">
+            <div class="modal-head">
+                <h2><i class="fas fa-clock-rotate-left"></i> Build history — <span id="historyName"></span></h2>
+                <button type="button" class="modal-close" onclick="closeHistory()">&times;</button>
+            </div>
+            <div class="modal-body" id="historyBody">
+                <div class="loading">Loading…</div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        const historyModal = document.getElementById('historyModal');
+
+        function closeHistory() { historyModal.classList.remove('open'); }
+        document.addEventListener('keydown', e => { if (e.key === 'Escape') closeHistory(); });
+
+        function esc(s) {
+            return String(s == null ? '' : s).replace(/[&<>"']/g, c => (
+                {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]
+            ));
+        }
+
+        async function showHistory(cfgId, name) {
+            document.getElementById('historyName').textContent = name;
+            document.getElementById('historyBody').innerHTML = '<div class="loading">Loading…</div>';
+            historyModal.classList.add('open');
+            try {
+                const resp = await fetch(`/configs/${cfgId}/history`);
+                if (!resp.ok) throw new Error('HTTP ' + resp.status);
+                const data = await resp.json();
+                renderHistory(cfgId, data.builds || []);
+            } catch (err) {
+                document.getElementById('historyBody').innerHTML =
+                    `<div class="loading">Failed to load history (${esc(err.message)}).</div>`;
+            }
+        }
+
+        function renderHistory(cfgId, builds) {
+            if (!builds.length) {
+                document.getElementById('historyBody').innerHTML =
+                    '<div class="loading">No builds yet for this configuration.</div>';
+                return;
+            }
+            let rows = '';
+            builds.forEach((b, i) => {
+                const when = b.started_at || b.timestamp || '';
+                const current = i === 0 ? ' <span class="muted">(current)</span>' : '';
+                const statusCls = (b.status || 'unknown').replace(/[^a-z_]/gi, '');
+                let artifacts = '<span class="muted">—</span>';
+                if (b.artifacts && b.artifacts.length) {
+                    artifacts = b.artifacts.map(a =>
+                        `<a class="artifact-link" href="/configs/${cfgId}/builds/${encodeURIComponent(b.timestamp)}/download?file=${encodeURIComponent(a)}">` +
+                        `<i class="fas fa-download"></i> ${esc(a)}</a>`
+                    ).join('');
+                }
+                const log = b.log_url
+                    ? `<a class="artifact-link" href="${esc(b.log_url)}" target="_blank"><i class="fas fa-up-right-from-square"></i> log</a>`
+                    : '<span class="muted">—</span>';
+                rows += `<tr>
+                    <td>${esc(when)}${current}</td>
+                    <td><span class="status ${statusCls}"${b.error ? ` title="${esc(b.error)}"` : ''}>${esc(b.status || 'unknown')}</span></td>
+                    <td>${esc(b.platform)} <span class="muted">${esc(b.version)}</span></td>
+                    <td>${artifacts}</td>
+                    <td>${log}</td>
+                </tr>`;
+            });
+            document.getElementById('historyBody').innerHTML = `
+                <table>
+                    <thead><tr><th>Build</th><th>Status</th><th>Platform</th><th>Artifacts</th><th>Log</th></tr></thead>
+                    <tbody>${rows}</tbody>
+                </table>`;
+        }
+    </script>
 </body>
 </html>

--- a/rdgenerator/templates/generator.html
+++ b/rdgenerator/templates/generator.html
@@ -125,19 +125,16 @@
             max-height: 100px;
             margin-top: 10px;
         }
-        .save-load-section-container { /* New container for fixed positioning */
-            position: fixed;
-            top: 20px; /* Adjust as needed */
-            left: 20px; /* Adjust as needed */
-            background-color: #111; /* Match your section background */
-            padding: 0px;
-            border-radius: 8px;
-            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-            z-index: 100; /* Ensure it's above other content */
+        .config-actions-row {
+            max-width: 1200px;
+            margin: 0 auto 10px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
         }
-        .save-load-section {
-            display: none; /* Initially hidden */
-        }
+        .config-actions a { margin-left: 20px; }
+        .text-link { color: #4d9fff; text-decoration: none; cursor: pointer; }
+        .text-link:hover { text-decoration: underline; }
         .error {
             color: red;
         }
@@ -226,22 +223,23 @@
 <body>
     {% if save_mode %}
     <h1><i class="fas fa-cogs"></i> {% if config_id %}Edit{% else %}New{% endif %} Configuration</h1>
-    <div style="max-width:1200px;margin:0 auto 10px;"><a href="/configs" style="color:#4d9fff;text-decoration:none;"><i class="fas fa-arrow-left"></i> Back to configurations</a></div>
     <form id="myForm" action="/configs/save" method="post" enctype="multipart/form-data">
         <input type="hidden" name="config_id" value="{{ config_id }}">
     {% else %}
     <h1><i class="fas fa-cogs"></i> RustDesk Custom Client Builder</h1>
     <form id="myForm" action="/generator" method="post" enctype="multipart/form-data">
     {% endif %}
-        <div class="save-load-section-container">
-            <div class="section">
-                <h2 id="saveLoadTitle">Save/Load Configuration <i class="fas fa-chevron-down"></i></h2>  
-                <div class="save-load-section">  
-                    <button type="button" onclick="saveFormData()">Save Configuration</button>
-                    <input type="file" id="fileInput" style="display:none;" accept=".json">
-                    <button type="button" onclick="loadFormData()">Load Configuration</button>
-                </div>
-            </div>
+        <div class="config-actions-row">
+            {% if save_mode %}
+            <a href="/configs" class="text-link"><i class="fas fa-arrow-left"></i> Back to configurations</a>
+            {% else %}
+            <span></span>
+            {% endif %}
+            <span class="config-actions">
+                <a href="#" class="text-link" onclick="saveFormData(); return false;">Save Configuration</a>
+                <input type="file" id="fileInput" style="display:none;" accept=".json">
+                <a href="#" class="text-link" onclick="loadFormData(); return false;">Load Configuration</a>
+            </span>
         </div>
         {% if form.iconfile.errors %}
             <ul class="errorlist">
@@ -565,21 +563,6 @@
                 reader.readAsDataURL(input.files[0]);
             }
         }
-        const saveLoadTitle = document.getElementById("saveLoadTitle");
-        const saveLoadSection = document.querySelector(".save-load-section");
-
-        saveLoadTitle.addEventListener("click", () => {
-            if (!saveLoadSection.style.display || saveLoadSection.style.display === "none") {
-                saveLoadSection.style.display = "block";
-            } else {
-                saveLoadSection.style.display = "none";
-            }
-
-            const icon = saveLoadTitle.querySelector("i");
-            icon.classList.toggle("fa-chevron-down");
-            icon.classList.toggle("fa-chevron-up");
-        });
-
         async function saveFormData() {
             const filename = document.getElementById("{{ form.exename.id_for_label }}").value;
             if (!filename) {

--- a/rdgenerator/templates/generator.html
+++ b/rdgenerator/templates/generator.html
@@ -446,6 +446,20 @@
             previewImage(event.target, 'privacy-preview');
         });
 
+        // Show previews for images already saved on this config (edit mode):
+        // the hidden base64 fields are pre-filled by the server.
+        (function showSavedImagePreviews() {
+            [["{{ form.iconbase64.id_for_label }}", 'icon-preview'],
+             ["{{ form.logobase64.id_for_label }}", 'logo-preview'],
+             ["{{ form.privacybase64.id_for_label }}", 'privacy-preview']].forEach(([fieldId, previewId]) => {
+                const field = document.getElementById(fieldId);
+                const preview = document.getElementById(previewId);
+                if (field && preview && field.value && field.value.startsWith('data:image')) {
+                    preview.innerHTML = `<img src="${field.value}" style="max-width:300px;max-height:60px;">`;
+                }
+            });
+        })();
+
         document.getElementById("{{ form.hidecm.id_for_label }}").addEventListener('change',function() {
             if (this.checked) {
                 document.getElementById("passwordRequirement").style.display = 'block';

--- a/rdgenerator/templates/generator.html
+++ b/rdgenerator/templates/generator.html
@@ -224,8 +224,15 @@
       </style>
 </head>
 <body>
+    {% if save_mode %}
+    <h1><i class="fas fa-cogs"></i> {% if config_id %}Edit{% else %}New{% endif %} Configuration</h1>
+    <div style="max-width:1200px;margin:0 auto 10px;"><a href="/configs" style="color:#4d9fff;text-decoration:none;"><i class="fas fa-arrow-left"></i> Back to configurations</a></div>
+    <form id="myForm" action="/configs/save" method="post" enctype="multipart/form-data">
+        <input type="hidden" name="config_id" value="{{ config_id }}">
+    {% else %}
     <h1><i class="fas fa-cogs"></i> RustDesk Custom Client Builder</h1>
     <form id="myForm" action="/generator" method="post" enctype="multipart/form-data">
+    {% endif %}
         <div class="save-load-section-container">
             <div class="section">
                 <h2 id="saveLoadTitle">Save/Load Configuration <i class="fas fa-chevron-down"></i></h2>  
@@ -258,13 +265,7 @@
                     <i class="fab fa-android platform-icon" data-platform="android"></i>
                     <i class="fab fa-apple platform-icon" data-platform="macos"></i>
                 </div>
-                <select name="platform" id="id_platform">
-                    <option value="windows" selected>Windows 64Bit</option>
-                    <option value="windows-x86">Windows 32Bit</option>
-                    <option value="linux">Linux</option>
-                    <option value="android">Android</option>
-                    <option value="macos">macOS</option>
-                </select>
+                {{ form.platform }}
                 <label for="{{ form.version.id_for_label }}">Rustdesk Version:</label>
                 {{ form.version }}
                 {% if form.version.help_text %}
@@ -279,6 +280,10 @@
                 <h2><i class="fas fa-sliders-h"></i> General</h2>
                     <label for="{{ form.exename.id_for_label }}">Name of the configuration (no spaces or special characters, English characters only):</label>
                     {{ form.exename }}<span id="filenameError" class="error"></span><br><br>
+                    {% if save_mode %}
+                    <label for="id_note">Note (optional):</label>
+                    <input type="text" name="note" id="id_note" value="{{ note }}"><br><br>
+                    {% endif %}
                     <label for="{{ form.appname.id_for_label }}">Custom Application Name (leave blank to use default):</label>
                     {{ form.appname }}<br><br>
                     <label for="{{ form.direction.id_for_label }}">Connection Type:</label>
@@ -387,7 +392,11 @@
         </div>
         <div class="platform">
             <div class="section">
+                {% if save_mode %}
+                <button type="submit"><i class="fas fa-save"></i> Save Configuration</button>
+                {% else %}
                 <button type="submit"><i class="fas fa-rocket"></i> Generate Custom Client</button>
+                {% endif %}
             </div>
         </div>
         <div style="text-align: center; margin: 30px 0;">
@@ -415,6 +424,18 @@
                 document.getElementById('id_platform').value = this.dataset.platform;
             });
         });
+        // Keep the highlighted platform icon in sync with the (possibly pre-filled) select.
+        (function syncPlatformIcon() {
+            const select = document.getElementById('id_platform');
+            if (!select) return;
+            const apply = () => {
+                document.querySelectorAll('.platform-icon').forEach(i => {
+                    i.classList.toggle('active', i.dataset.platform === select.value);
+                });
+            };
+            select.addEventListener('change', apply);
+            apply();
+        })();
         document.getElementById("{{ form.iconfile.id_for_label }}").addEventListener('change', function(event) {
             previewImage(event.target, 'icon-preview');
         });

--- a/rdgenerator/templates/generator.html
+++ b/rdgenerator/templates/generator.html
@@ -287,6 +287,8 @@
                     {{ form.installation }}<br><br>
                     <label for="{{ form.settings.id_for_label }}">Disable Settings:</label>
                     {{ form.settings }}<br><br>
+                    <label for="{{ form.account.id_for_label }}">Disable Account:</label>
+                    {{ form.account }}<br><br>
                     <label for="{{ form.androidappid.id_for_label }}">Custom Android App ID (replaces 'com.carriez.flutter_hbb', leave blank to use default):</label>
                     {{ form.androidappid }}<br><br>
             </div>

--- a/rdgenerator/views.py
+++ b/rdgenerator/views.py
@@ -561,7 +561,9 @@ def save_png(file, uuid, domain, name):
 
     if isinstance(file, str):  # Check if it's a base64 string
         try:
-            header, encoded = file.split(';base64,')
+            # LT-158: accept a full data URL (data:image/png;base64,XXXX) OR raw
+            # base64 with no prefix (what the web UI actually POSTs).
+            encoded = file.split(';base64,', 1)[1] if ';base64,' in file else file
             decoded_img = base64.b64decode(encoded)
             file = ContentFile(decoded_img, name=name) # Create a file-like object
         except ValueError:

--- a/rdgenerator/views.py
+++ b/rdgenerator/views.py
@@ -57,6 +57,7 @@ def generate_custom_client(params, full_url):
     direction = params.get('direction', 'both')
     installation = params.get('installation', 'installationY')
     settings = params.get('settings', 'settingsY')
+    account = params.get('account', 'accountY')
     appname = params.get('appname', '')
     if not appname:
         appname = "rustdesk"
@@ -141,6 +142,8 @@ def generate_custom_client(params, full_url):
         decodedCustom['disable-installation'] = 'Y'
     if settings == "settingsN":
         decodedCustom['disable-settings'] = 'Y'
+    if account == "accountN":
+        decodedCustom['disable-account'] = 'Y'
     if appname.upper != "rustdesk".upper and appname != "":
         decodedCustom['app-name'] = appname
     decodedCustom['override-settings'] = {}

--- a/rdgenerator/views.py
+++ b/rdgenerator/views.py
@@ -15,11 +15,12 @@ from django.conf import settings as _settings
 from django.db.models import Q
 from .forms import GenerateForm
 from .models import GithubRun
+from . import config_store
 from PIL import Image
 from urllib.parse import quote
 
 
-def generate_custom_client(params, full_url):
+def generate_custom_client(params, full_url, dest=None):
     """
     Core generation logic shared by web form and JSON API.
 
@@ -272,7 +273,8 @@ def generate_custom_client(params, full_url):
         "removeNewVersionNotif": 'true' if removeNewVersionNotif else 'false',
         "compname": compname,
         "androidappid":androidappid,
-        "filename":filename
+        "filename":filename,
+        "dest": dest or ""
     }
 
     temp_json_path = f"data_{uuid.uuid4()}.json"
@@ -322,6 +324,14 @@ def generate_custom_client(params, full_url):
             new_github_run.github_run_id = github_data.get('workflow_run_id')
             new_github_run.status = "in_progress"
             new_github_run.save()
+
+            # Saved-config builds land under builds/<cfg>/<ts>/; record the build
+            # and index build_uuid -> dir so the callbacks can find it (Option A).
+            if dest:
+                cfg, _, ts = dest.partition('/')
+                if config_store.is_valid_config_id(cfg) and config_store.is_valid_build_id(ts):
+                    config_store.start_build(cfg, ts, myuuid,
+                                             new_github_run.github_run_id, platform, version)
 
             return {
                 "success": True,
@@ -486,6 +496,8 @@ def update_github_run(request):
     myuuid = data.get('uuid')
     mystatus = data.get('status')
     GithubRun.objects.filter(Q(uuid=myuuid)).update(status=mystatus)
+    # Mirror the status onto the saved-config build, if this uuid is one.
+    config_store.update_build_status(myuuid, mystatus)
     return HttpResponse('')
 
 def resize_and_encode_icon(imagefile):
@@ -589,11 +601,23 @@ def save_png(file, uuid, domain, name):
 def save_custom_client(request):
     file = request.FILES['file']
     myuuid = request.POST.get('uuid')
-    file_save_path = "exe/%s/%s" % (myuuid, file.name)
-    Path("exe/%s" % myuuid).mkdir(parents=True, exist_ok=True)
-    with open(file_save_path, "wb+") as f:
+
+    # Option A: resolve the saved-config build dir from the build uuid. Falls
+    # back to the legacy exe/<uuid>/ path for the plain single-shot generator.
+    resolved = config_store.resolve_build(myuuid)
+    base_dir = resolved[2] if resolved else os.path.abspath("exe/%s" % myuuid)
+
+    Path(base_dir).mkdir(parents=True, exist_ok=True)
+    save_path = os.path.abspath(os.path.join(base_dir, file.name))
+    if not save_path.startswith(base_dir + os.sep):
+        return HttpResponseForbidden("Invalid filename")
+
+    with open(save_path, "wb+") as f:
         for chunk in file.chunks():
             f.write(chunk)
+
+    if resolved:
+        config_store.record_artifact(myuuid, file.name)
 
     return HttpResponse("File saved successfully!")
 

--- a/setup.md
+++ b/setup.md
@@ -33,6 +33,36 @@
 5. Now just run ```docker compose up -d```
 
 
+## Saved configurations
+
+The server includes a **Saved Configurations** console at `/configs`. It lets you
+create, edit, duplicate and delete named client configurations, kick off builds
+from a table, and review each config's build history — all persisted on disk so
+they survive restarts (no database rows are used).
+
+Everything lives under a `builds/` directory, one UUID subdirectory per config:
+
+```
+builds/
+  <config-uuid>/
+    config.json                 # the saved configuration
+    assets/                     # persisted icon/logo/privacy PNGs
+    <UTC-timestamp>/            # one directory per build
+      build.json                # status, GitHub run id, artifacts
+      <artifacts>               # the generated client(s)
+```
+
+* **Docker:** the provided `docker-compose.yml` mounts `./builds:/opt/rdgen/builds`.
+  Keep this volume to retain configs and builds across container recreation.
+* **Manual host:** `builds/` is created automatically in the working directory.
+  Set the `BUILDS_ROOT` environment variable to store it elsewhere.
+
+Building a saved config routes its artifacts into
+`builds/<config>/<timestamp>/` with no changes to the generator workflows — the
+server resolves each build's destination from the build UUID the workflow
+already reports back.
+
+
 ## Use a self hosted github runner for faster client generation (Windows only right now)
 
 1. First you need to set up a Windows computer that can build rustdesk


### PR DESCRIPTION
## Summary
- The **Last Build** column on the saved-configs landing page (`/configs`) was reading status straight from the build's `build.json`, which only ever gets written to `in_progress` when the build is dispatched.
- The intended GitHub Actions completion callback (`STATUS_URL` → `/updategh`) is set as an env var in every generator workflow but is never actually invoked anywhere in those workflows — dead wiring.
- The only code path that polled GitHub for the real status was the History modal (`config_history`), which mirrors the fresh status back to `build.json` as a side effect — explaining why opening History and then refreshing the page "fixed" the column.
- `configs_list()` now reconciles each row's non-terminal `last_build` status against GitHub the same way `config_history` already does (via `_get_run_status` / `store.update_build_status`), so the landing page itself stays accurate without needing a trip through History first.

## Test plan
- [ ] Kick off a build from a saved config, confirm the row shows `in_progress`
- [ ] Wait for the GitHub Actions workflow to finish
- [ ] Reload `/configs` directly (without opening History first) and confirm the Last Build column shows the finished status (`success`/`failure`/etc.)
- [ ] Confirm History modal still works and shows consistent status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bAgGA6DvCapyPaDUAHd9D